### PR TITLE
Handle times better

### DIFF
--- a/app.py
+++ b/app.py
@@ -156,10 +156,9 @@ def live_results_table(race_name, gender=None):
             earliest_start = int(race.get('earliestStartTime', 0))
 
             if current_time < earliest_start:
-                start_time = datetime.fromtimestamp(earliest_start)
                 message = {
-                    'text': "This race hasn't yet started.  Racers should be on the course starting around:",
-                    'datetime': start_time.strftime('%B %d, %Y at %I:%M %p %Z')
+                    'text': "This race hasn't yet started. Racers should be on the course starting around:",
+                    'timestamp': earliest_start * 1000  # Convert to milliseconds for JavaScript
                 }
             else:
                 finish_offset = timedelta(hours=7.5 if race['distance'] == '140.6' else 3.5)
@@ -167,12 +166,12 @@ def live_results_table(race_name, gender=None):
                 if current_time < expected_finish.timestamp():
                     message = {
                         'text': "Racers are probably on the course right now. Results will start filling in here as they cross the finish line, likely sometime after:",
-                        'datetime': expected_finish.strftime('%B %d, %Y at %I:%M %p %Z')
+                        'timestamp': int(expected_finish.timestamp() * 1000)  # Convert to milliseconds for JavaScript
                     }
                 else:
                     message = {
                         'text': "No racers have crossed the finish line yet. Results will appear here as soon as racers finish.",
-                        'datetime': None
+                        'timestamp': None
                     }
             return render_template('live_results.html', results=[], error=message)
         else:

--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 import os
 import json
-from flask import Flask, render_template, abort, jsonify, redirect, url_for
-from datetime import date
+from flask import Flask, render_template, abort, jsonify, redirect, url_for, current_app
+from datetime import date, datetime, timedelta
 import parse_live_data
 
 app = Flask(__name__)
@@ -29,19 +29,22 @@ AG_ADJUSTMENTS_1406 = load_ag_adjustments('ag_adjustments_1406.json')
 def get_races():
     with open(full_path('races.json'), 'r') as f:
         races = json.load(f)
-# Get today's date
-    today = date.today()
 
-    # Filter out races that happen after today
-    races_on_or_before_today = [
+    # Get cutoff timestamp - current time by default, extended if in debug mode
+    cutoff = int(datetime.now().timestamp())
+    if current_app.debug:
+        cutoff += 7 * 24 * 60 * 60  # Add 7 days in seconds if in debug mode
+
+    # Filter races based on the cutoff time
+    filtered_races = [
         race for race in races
-        if date.fromisoformat(race['date']) <= today
+        if 'earliestStartTime' in race and int(race['earliestStartTime']) <= cutoff
     ]
 
-    # Sort the filtered races by date in descending order
-    races_on_or_before_today.sort(key=lambda x: x['date'], reverse=True)
+    # Sort the filtered races by earliestStartTime in descending order
+    filtered_races.sort(key=lambda x: int(x['earliestStartTime']) if 'earliestStartTime' in x else 0, reverse=True)
 
-    return races_on_or_before_today
+    return filtered_races
 
 # Functions to convert between display names and URL-friendly names
 def to_url_friendly_name(race_name):
@@ -147,8 +150,33 @@ def live_results_table(race_name, gender=None):
     processed_data = parse_live_data.get_processed_results(race, gender, ag_adjustments)
 
     if "error" in processed_data:
-        error_message = processed_data["msg"] if isinstance(processed_data["error"], str) and processed_data["error"] == "no_finishers" else processed_data["error"]
-        return render_template('live_results.html', results=[], error=error_message)
+        # Only handle special messaging for no_finishers error
+        if isinstance(processed_data["error"], str) and processed_data["error"] == "no_finishers":
+            current_time = int(datetime.now().timestamp())
+            earliest_start = int(race.get('earliestStartTime', 0))
+
+            if current_time < earliest_start:
+                start_time = datetime.fromtimestamp(earliest_start)
+                message = {
+                    'text': "This race hasn't yet started.  Racers should be on the course starting around:",
+                    'datetime': start_time.strftime('%B %d, %Y at %I:%M %p %Z')
+                }
+            else:
+                finish_offset = timedelta(hours=7.5 if race['distance'] == '140.6' else 3.5)
+                expected_finish = datetime.fromtimestamp(earliest_start) + finish_offset
+                if current_time < expected_finish.timestamp():
+                    message = {
+                        'text': "Racers are probably on the course right now. Results will start filling in here as they cross the finish line, likely sometime after:",
+                        'datetime': expected_finish.strftime('%B %d, %Y at %I:%M %p %Z')
+                    }
+                else:
+                    message = {
+                        'text': "No racers have crossed the finish line yet. Results will appear here as soon as racers finish.",
+                        'datetime': None
+                    }
+            return render_template('live_results.html', results=[], error=message)
+        else:
+            return render_template('live_results.html', results=[], error=processed_data["error"])
 
     return render_template('live_results.html', results=processed_data)
 

--- a/parse_live_data.py
+++ b/parse_live_data.py
@@ -54,7 +54,7 @@ def fetch_live_results(api_url):
 
         # Handle the specific "no_results" error
         if "error" in raw_data and raw_data["error"]["type"] == "no_results":
-            return {"error": "no_finishers", "msg": "No racers have crossed the finish line yet. The age-graded results will start populating once racers start finishing the race."}
+            return {"error": "no_finishers"}
 
         return raw_data
     except requests.exceptions.RequestException as e:

--- a/races.json
+++ b/races.json
@@ -16,7 +16,9 @@
                 "men": "https://cdn-1.sportstats.one/rolldown/IRONMAN%2070.3%20Wisconsin_70.3_Men.html",
                 "women": "https://cdn-1.sportstats.one/rolldown/IRONMAN%2070.3%20Wisconsin_70.3_Women.html"
             }
-        }
+        },
+        "earliestStartTime": "1757160000",
+        "key": "IRM-WISCONSIN703-2025"
     },
     {
         "date": "2025-09-07",
@@ -29,7 +31,9 @@
                 "women": "https://api.rtrt.me/events/IRM-WISCONSIN-2025/categories/top-age-group-women-divison-ironman-tri_ironman%3A_ALL/splits/FINISH"
             },
             "official_ag": "https://cdn-1.sportstats.one/rolldown/IRONMAN%20Wisconsin_Ironman.html"
-        }
+        },
+        "earliestStartTime": "1757246400",
+        "key": "IRM-WISCONSIN-2025"
     },
     {
         "date": "2025-09-14",
@@ -42,7 +46,9 @@
                 "women": "https://api.rtrt.me/events/IRM-JAPAN-2025/categories/top-age-group-women-division-im-ironman%3A_ALL/splits/FINISH"
             },
             "official_ag": "https://static.rtrt.me/events/irm-japan-2025/info_section/1757881986_ironman-japan-age-graded-overall-table-1_2025-09-14-203341_u5udkajl.pdf"
-        }
+        },
+        "earliestStartTime": "1757799000",
+        "key": "IRM-JAPAN-2025"
     },
     {
         "date": "2025-09-14",
@@ -61,7 +67,9 @@
                 "men": "https://cdn-1.sportstats.one/rolldown/IRONMAN%2070.3%20Sunshine%20Coast_70.3_Men.html",
                 "women": "https://cdn-1.sportstats.one/rolldown/IRONMAN%2070.3%20Sunshine%20Coast_70.3_Women.html"
             }
-        }
+        },
+        "earliestStartTime": "1757793300",
+        "key": "IRM-SUNSHINECOAST703-2025"
     },
     {
         "date": "2025-09-14",
@@ -80,7 +88,9 @@
                 "men": "https://cdn-1.sportstats.one/rolldown/IRONMAN%2070.3%20Weymouth_70.3_Men.html",
                 "women": "https://cdn-1.sportstats.one/rolldown/IRONMAN%2070.3%20Weymouth_70.3_Women.html"
             }
-        }
+        },
+        "earliestStartTime": "1757832000",
+        "key": "IRM-WEYMOUTH703-2025"
     },
     {
         "date": "2025-09-14",
@@ -99,7 +109,9 @@
                 "men": "https://static.rtrt.me/events/irm-michigan703-2025/info_section/1757887981_ironman-70.3-michigan-age-graded-men-top-250-3_2025-09-14-221310_u5udkajl.pdf",
                 "women": "https://static.rtrt.me/events/irm-michigan703-2025/info_section/1757882257_ironman-70.3-michigan-age-graded-women-top-250_2025-09-14-203758_u5udkajl.pdf"
             }
-        }
+        },
+        "earliestStartTime": "1757850600",
+        "key": "IRM-MICHIGAN703-2025"
     },
     {
         "date": "2025-09-14",
@@ -118,7 +130,9 @@
                 "men": "https://static.rtrt.me/events/irm-erkner703-2025/info_section/1757870115_ironman-70.3-erkner-age-graded-men-top-250-2_2025-09-14-171543_u5udkajl.pdf",
                 "women": "https://static.rtrt.me/events/irm-erkner703-2025/info_section/1757870156_ironman-70.3-erkner-age-graded-women-top-250_2025-09-14-171617_u5udkajl.pdf"
             }
-        }
+        },
+        "earliestStartTime": "1757829600",
+        "key": "IRM-ERKNER703-2025"
     },
     {
         "date": "2025-09-20",
@@ -131,7 +145,9 @@
                 "women": "https://api.rtrt.me/events/IRM-ITALYEMILIA-2025/categories/top-age-group-women-division-ironman:_ALL/splits/FINISH"
             },
             "official_ag": "https://cdn-1.sportstats.one/rolldown/IRONMAN%20Italy%20Emilia-Romagna_IRONMAN.html"
-        }
+        },
+        "earliestStartTime": "1758346200",
+        "key": "IRM-ITALYEMILIA-2025"
     },
     {
         "date": "2025-09-20",
@@ -144,7 +160,9 @@
                 "women": "https://api.rtrt.me/events/IRM-MARYLAND-2025/categories/top-age-group-women-divison-ironman-tri_ironman:_ALL/splits/FINISH"
             },
             "official_ag": "https://cdn-1.sportstats.one/rolldown/IRONMAN%20Maryland_IRONMAN.html"
-        }
+        },
+        "earliestStartTime": "1758365100",
+        "key": "IRM-MARYLAND-2025"
     },
     {
         "date": "2025-09-20",
@@ -163,7 +181,9 @@
                 "men": "https://cdn-1.sportstats.one/rolldown/IRONMAN%2070.3%20New%20York_70.3_Men.html",
                 "women": "https://cdn-1.sportstats.one/rolldown/IRONMAN%2070.3%20New%20York_70.3_Women.html"
             }
-        }
+        },
+        "earliestStartTime": "1758364200",
+        "key": "IRM-NEWYORK703-2025"
     },
     {
         "date": "2025-09-21",
@@ -176,7 +196,9 @@
                 "women": "https://api.rtrt.me/events/IRM-WALES-2025/categories/top-age-group-women-divison-ironman-tri_ironman:_ALL/splits/FINISH"
             },
             "official_ag": "https://cdn-1.sportstats.one/rolldown/IRONMAN%20Wales_IRONMAN.html"
-        }
+        },
+        "earliestStartTime": "1758436200",
+        "key": "IRM-WALES-2025"
     },
     {
         "date": "2025-09-21",
@@ -195,7 +217,9 @@
                 "men": "https://cdn-1.sportstats.one/rolldown/IRONMAN%2070.3%20Western%20Sydney_70.3_Men.html",
                 "women": "https://cdn-1.sportstats.one/rolldown/IRONMAN%2070.3%20Western%20Sydney_70.3_Women.html"
             }
-        }
+        },
+        "earliestStartTime": "1758401400",
+        "key": "IRM-WESTERNSYDNEY703-2025"
     },
     {
         "date": "2025-09-21",
@@ -214,7 +238,9 @@
                 "men": "https://cdn-1.sportstats.one/rolldown/IRONMAN%2070.3%20Washington_70.3_Men.html",
                 "women": "https://cdn-1.sportstats.one/rolldown/IRONMAN%2070.3%20Washington_70.3_Women.html"
             }
-        }
+        },
+        "earliestStartTime": "1758461400",
+        "key": "IRM-WASHINGTON703-2025"
     },
     {
         "date": "2025-09-21",
@@ -233,7 +259,9 @@
                 "men": "https://cdn-1.sportstats.one/rolldown/IRONMAN%2070.3%20Cozumel_70.3_Men.html",
                 "women": "https://cdn-1.sportstats.one/rolldown/IRONMAN%2070.3%20Cozumel_70.3_Women.html"
             }
-        }
+        },
+        "earliestStartTime": "1758454200",
+        "key": "IRM-COZUMEL703-2025"
     },
     {
         "date": "2025-09-21",
@@ -252,7 +280,9 @@
                 "men": "https://cdn-1.sportstats.one/rolldown/IRONMAN%2070.3%20S%C3%A3o%20Paulo_70.3_Men.html",
                 "women": "https://cdn-1.sportstats.one/rolldown/IRONMAN%2070.3%20S%C3%A3o%20Paulo_70.3_Women.html"
             }
-        }
+        },
+        "earliestStartTime": "1758445200",
+        "key": "IRM-SAOPAULO703-2025"
     },
     {
         "date": "2025-09-21",
@@ -290,7 +320,9 @@
                 "men": "https://cdn-1.sportstats.one/rolldown/IRONMAN%2070.3%20Belgrade_70.3_Men.html",
                 "women": "https://cdn-1.sportstats.one/rolldown/IRONMAN%2070.3%20Belgrade_70.3_Women.html"
             }
-        }
+        },
+        "earliestStartTime": "1758427200",
+        "key": "IRM-SERBIA703-2025"
     },
     {
         "date": "2025-09-28",
@@ -303,7 +335,9 @@
                 "women": "https://api.rtrt.me/events/IRM-CHATTANOOGA-2025/categories/top-age-group-women-division-ironman%3A_ALL/splits/FINISH"
             },
             "official_ag": ""
-        }
+        },
+        "earliestStartTime": "1759058400",
+        "key": "IRM-CHATTANOOGA-2025"
     },
     {
         "date": "2025-09-28",
@@ -316,7 +350,9 @@
                 "women": "https://api.rtrt.me/events/IRM-GURYE-2025/categories/top-age-group-women-divison-ironman%3A_ALL/splits/FINISH"
             },
             "official_ag": ""
-        }
+        },
+        "earliestStartTime": "1759010400",
+        "key": "IRM-GURYE-2025"
     },
     {
         "date": "2025-09-28",
@@ -335,7 +371,9 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1759056900",
+        "key": "IRM-AUGUSTA703-2025"
     },
     {
         "date": "2025-09-28",
@@ -354,7 +392,9 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1759051800",
+        "key": "IRM-PARAGUAY703-2025"
     },
     {
         "date": "2025-10-05",
@@ -367,7 +407,9 @@
                 "women": "https://api.rtrt.me/events/IRM-CALELLABARCELONA-2025/categories/top-age-group-women-divison-ironman%3A_ALL/splits/FINISH"
             },
             "official_ag": ""
-        }
+        },
+        "earliestStartTime": "1759643400",
+        "key": "IRM-BARCELONA-2025"
     },
     {
         "date": "2025-10-05",
@@ -386,7 +428,9 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1759667100",
+        "key": "IRM-WACO703-2025"
     },
     {
         "date": "2025-10-18",
@@ -399,7 +443,9 @@
                 "women": "https://api.rtrt.me/events/IRM-PORTUGALCASCAIS-2025/categories/top-age-group-women-divison-ironman%3A_ALL/splits/FINISH"
             },
             "official_ag": ""
-        }
+        },
+        "earliestStartTime": "1760769600",
+        "key": "IRM-CASCAIS-2025"
     },
     {
         "date": "2025-10-18",
@@ -418,7 +464,9 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1760769600",
+        "key": "IRM-CASCAIS-2025"
     },
     {
         "date": "2025-10-19",
@@ -437,7 +485,9 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1760853600",
+        "key": "IRM-CROATIA703-2025"
     },
     {
         "date": "2025-10-25",
@@ -456,7 +506,9 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1761359400",
+        "key": "IRM-SALALAH703-2025"
     },
     {
         "date": "2025-10-25",
@@ -475,7 +527,9 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1761390600",
+        "key": "IRM-NORTHCAROLINA703-2025"
     },
     {
         "date": "2025-10-26",
@@ -488,7 +542,9 @@
                 "women": "https://api.rtrt.me/events/IRM-CALIFORNIA-2025/categories/top-age-group-women-division-ironman-route_b%3A_ALL/splits/FINISH"
             },
             "official_ag": ""
-        }
+        },
+        "earliestStartTime": "1760881200",
+        "key": "IRM-CALIFORNIA-2025"
     },
     {
         "date": "2025-10-26",
@@ -558,7 +614,9 @@
                 "women": "https://api.rtrt.me/events/IRM-FLORIDA-2025/categories/top-age-group-women-division-ironman-route_b%3A_ALL/splits/FINISH"
             },
             "official_ag": ""
-        }
+        },
+        "earliestStartTime": "1761997200",
+        "key": "IRM-FLORIDA-2025"
     },
     {
         "date": "2025-11-01",
@@ -571,7 +629,9 @@
                 "women": "https://api.rtrt.me/events/IRM-MALAYSIA-2025/categories/top-age-group-women-divison-ironman%3A_ALL/splits/FINISH"
             },
             "official_ag": ""
-        }
+        },
+        "earliestStartTime": "1761951600",
+        "key": "IRM-MALAYSIA-2025"
     },
     {
         "date": "2025-11-01",
@@ -590,7 +650,9 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1761951600",
+        "key": "IRM-LANGKAWI703-2025"
     },
     {
         "date": "2025-11-02",
@@ -628,7 +690,9 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1762034400",
+        "key": "IRM-KENTING703-2025"
     },
     {
         "date": "2025-11-02",
@@ -647,7 +711,9 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1762059600",
+        "key": "IRM-TURKEY703-2025"
     },
     {
         "date": "2025-11-09",
@@ -666,7 +732,9 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1762651800",
+        "key": "IRM-GOA703-2025"
     },
     {
         "date": "2025-11-09",
@@ -685,7 +753,9 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1762628400",
+        "key": "IRM-MELBOURNE703-2025"
     },
     {
         "date": "2025-11-09",
@@ -704,7 +774,9 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1764508800",
+        "key": "IRM-ACAPULCO703-2025"
     },
     {
         "date": "2025-11-16",
@@ -717,7 +789,9 @@
                 "women": "https://api.rtrt.me/events/IRM-ARIZONA-2025/categories/top-age-group-women-divison-ironman-tri_ironman%3A_ALL/splits/FINISH"
             },
             "official_ag": ""
-        }
+        },
+        "earliestStartTime": "1763300700",
+        "key": "IRM-ARIZONA-2025"
     },
     {
         "date": "2025-11-16",
@@ -736,7 +810,9 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1763249400",
+        "key": "IRM-PHUQUOC703-2025"
     },
     {
         "date": "2025-11-16",
@@ -755,7 +831,9 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1763266500",
+        "key": "IRM-MOSSELBAY703-2025"
     },
     {
         "date": "2025-11-23",
@@ -787,7 +865,9 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1764506700",
+        "key": "IRM-VALDIVIA703-2025"
     },
     {
         "date": "2025-11-30",
@@ -806,7 +886,9 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1764501300",
+        "key": "IRM-CARTAGENA703-2025"
     },
     {
         "date": "2025-11-30",
@@ -825,7 +907,9 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1764491400",
+        "key": "IRM-ARACAJU-SERGIPE703-2025"
     },
     {
         "date": "2025-12-07",
@@ -876,7 +960,9 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1765119600",
+        "key": "IRM-INDIANWELLSLAQUINTA703-2025"
     },
     {
         "date": "2025-12-07",
@@ -895,7 +981,9 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1765056480",
+        "key": "IRM-WESTERNAUSTRALIA703-2025"
     },
     {
         "date": "2025-12-14",
@@ -914,6 +1002,8 @@
                 "men": "",
                 "women": ""
             }
-        }
+        },
+        "earliestStartTime": "1765713000",
+        "key": "IRM-FLORIDA703-2025"
     }
 ]

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -305,3 +305,23 @@ form {
 .hidden-label {
     display: none;
 }
+
+/* Status message styles */
+.status-message {
+    text-align: center;
+    font-size: 1.2em;
+    margin: 2em auto;
+    max-width: 800px;
+}
+
+.message-text {
+    margin-bottom: 0.5em;
+    color: #333;
+}
+
+.message-datetime {
+    font-size: 1.4em;
+    font-weight: bold;
+    color: #8B2635;
+    margin-top: 0.5em;
+}

--- a/templates/live_results.html
+++ b/templates/live_results.html
@@ -18,7 +18,12 @@
             </p>
         </div>
         {% if error %}
-            <p id="message-area">Error: {{ error }}</p>
+            <div id="message-area" class="status-message">
+                <p class="message-text">{{ error.text }}</p>
+                {% if error.datetime %}
+                    <p class="message-datetime">{{ error.datetime }}</p>
+                {% endif %}
+            </div>
         {% else %}
             <div id="results-table-container"></div>
         {% endif %}

--- a/templates/live_results.html
+++ b/templates/live_results.html
@@ -20,13 +20,34 @@
         {% if error %}
             <div id="message-area" class="status-message">
                 <p class="message-text">{{ error.text }}</p>
-                {% if error.datetime %}
-                    <p class="message-datetime">{{ error.datetime }}</p>
+                {% if error.timestamp %}
+                    <p class="message-datetime" data-timestamp="{{ error.timestamp }}"></p>
                 {% endif %}
             </div>
         {% else %}
             <div id="results-table-container"></div>
         {% endif %}
+
+        <script>
+            document.addEventListener('DOMContentLoaded', function() {
+                const datetimeElement = document.querySelector('.message-datetime');
+                if (datetimeElement) {
+                    const timestamp = parseInt(datetimeElement.getAttribute('data-timestamp'));
+                    const date = new Date(timestamp);
+                    const options = {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric',
+                        hour: 'numeric',
+                        minute: '2-digit',
+                        hour12: true,
+                        timeZoneName: 'short'
+                    };
+                    datetimeElement.textContent = date.toLocaleString(undefined, options);
+                }
+            });
+        </script>
+        
     </div>
 
     <script>


### PR DESCRIPTION
Fixed #16 and works towards #7 (but obviously lots more work to be done there).

Now sorts races by the earliestStartTime, and displays more-friendly messages for races that haven't yet started (only visible in debug mode) and in-progress races with no finishers yet (still needs to be verified since no races are currently in progress).