### PR TITLE
feat: redesign race controls and dark mode theming

### DIFF
--- a/app.py
+++ b/app.py
@@ -111,7 +111,8 @@ def filter_races_by_timestamp(races, debug_mode=False):
     if debug_mode:
         cutoff += 7 * 24 * 60 * 60  # Add 7 days in debug mode
     else:
-        cutoff += 1 * 24 * 60 * 60  # Add 1 day otherwise
+        # Include nearest upcoming weekend races in non-debug mode.
+        cutoff += 6 * 24 * 60 * 60
 
     # Filter races based on cutoff
     filtered_races = []
@@ -232,21 +233,221 @@ def get_rolldown_info(race, gender=None):
         'gender_text': ''
     }
 
+
+VALID_SOURCES = {'live', 'official_ag'}
+VALID_GENDERS = {'men', 'women'}
+
+
+def race_has_official_ag(race: dict) -> bool:
+    official = race.get('results_urls', {}).get('official_ag')
+    if race.get('distance') == '70.3':
+        if not isinstance(official, dict):
+            return False
+        men = official.get('men') if isinstance(official.get('men'), str) else ''
+        women = official.get('women') if isinstance(official.get('women'), str) else ''
+        return bool((men and men.strip()) or (women and women.strip()))
+
+    if isinstance(official, str):
+        return bool(official.strip())
+    if isinstance(official, dict):
+        men = official.get('men') if isinstance(official.get('men'), str) else ''
+        women = official.get('women') if isinstance(official.get('women'), str) else ''
+        return bool((men and men.strip()) or (women and women.strip()))
+    return False
+
+
+def official_ag_is_gendered(race: dict) -> bool:
+    if race.get('distance') != '140.6':
+        return False
+    official = race.get('results_urls', {}).get('official_ag')
+    if not isinstance(official, dict):
+        return False
+    men = official.get('men') if isinstance(official.get('men'), str) else ''
+    women = official.get('women') if isinstance(official.get('women'), str) else ''
+    return bool((men and men.strip()) or (women and women.strip()))
+
+
+def default_source_for_race(race: dict) -> str:
+    has_official_ag = race_has_official_ag(race)
+    earliest_start = int(race.get('earliestStartTime', 0) or 0)
+    now_ts = int(datetime.now().timestamp())
+
+    if earliest_start > 0:
+        if now_ts < earliest_start:
+            return 'live'
+        window_hours = 16 if race.get('distance') == '140.6' else 8
+        if now_ts < (earliest_start + window_hours * 3600):
+            return 'live'
+
+    return 'official_ag' if has_official_ag else 'live'
+
+
+def normalize_selection(race: dict, source: str | None = None, gender: str | None = None):
+    next_source = source if source in VALID_SOURCES else default_source_for_race(race)
+    has_official_ag = race_has_official_ag(race)
+    if next_source == 'official_ag' and not has_official_ag:
+        next_source = 'live'
+
+    policy = resolve_slot_policy(race)
+    requires_gender = policy_needs_gender(policy) or (next_source == 'official_ag' and official_ag_is_gendered(race))
+    if requires_gender:
+        if gender not in VALID_GENDERS:
+            gender = choose_default_gender(race)
+    else:
+        gender = None
+
+    return {
+        'race': race,
+        'source': next_source,
+        'gender': gender,
+        'requires_gender': requires_gender,
+    }
+
+
+def build_iframe_state(race: dict, source: str, gender: str | None = None):
+    iframe_url = None
+    coming_soon = True
+
+    if source == 'official_ag':
+        official = race.get('results_urls', {}).get('official_ag')
+        if race.get('distance') == '70.3' and isinstance(official, dict) and gender:
+            iframe_url = official.get(gender) or ''
+        elif race.get('distance') == '140.6':
+            if isinstance(official, dict) and gender:
+                iframe_url = official.get(gender) or ''
+            elif isinstance(official, str):
+                iframe_url = official
+        coming_soon = bool(iframe_url)
+    else:
+        coming_soon = False
+
+    return {
+        'iframe_url': iframe_url,
+        'coming_soon': coming_soon,
+    }
+
+
+def build_canonical_url(race_name: str, source: str, gender: str | None = None) -> str:
+    params = [('race', race_name), ('source', source)]
+    if gender:
+        params.append(('gender', gender))
+    query = '&'.join(f"{k}={v}" for k, v in params)
+    return f"/?{query}"
+
+
+def parse_race_date(race: dict) -> date | None:
+    raw = race.get('date')
+    if not raw or not isinstance(raw, str):
+        return None
+    try:
+        return datetime.strptime(raw, "%Y-%m-%d").date()
+    except Exception:
+        return None
+
+
+def _nearest_date_for_weekday(today: date, target_weekday: int) -> date:
+    days_since = (today.weekday() - target_weekday) % 7
+    previous = today - timedelta(days=days_since)
+    next_date = previous + timedelta(days=7)
+    if abs((today - previous).days) <= abs((next_date - today).days):
+        return previous
+    return next_date
+
+
+def nearest_weekend_dates(today: date) -> tuple[date, date]:
+    nearest_saturday = _nearest_date_for_weekday(today, 5)
+    nearest_sunday = _nearest_date_for_weekday(today, 6)
+    if abs((nearest_saturday - today).days) <= abs((nearest_sunday - today).days):
+        saturday = nearest_saturday
+        sunday = saturday + timedelta(days=1)
+    else:
+        sunday = nearest_sunday
+        saturday = sunday - timedelta(days=1)
+    return saturday, sunday
+
+
+def partition_races_for_controls(races: list[dict], today: date | None = None):
+    today = today or datetime.now().date()
+    saturday, sunday = nearest_weekend_dates(today)
+    weekend_dates = {saturday, sunday}
+
+    current = []
+    archive = []
+    for race in races:
+        race_date = parse_race_date(race)
+        if race_date and race_date in weekend_dates:
+            current.append(race)
+        else:
+            archive.append(race)
+
+    return current, archive
+
+
+def pick_default_race(races: list[dict], today: date | None = None):
+    if not races:
+        return None
+    today = today or datetime.now().date()
+
+    def distance_key(race: dict):
+        race_date = parse_race_date(race)
+        if not race_date:
+            return (10_000, 1)
+        diff = abs((race_date - today).days)
+        # Prefer future when equally close so users land on currently relevant weekends.
+        bias = 0 if race_date >= today else 1
+        return (diff, bias)
+
+    return min(races, key=distance_key)
+
+
+def format_current_race_label(name: str) -> str:
+    if not isinstance(name, str):
+        return ""
+    label = name.replace("Ironman 70.3 ", "IM70.3 ")
+    label = label.replace("Ironman ", "IM ")
+    return label
+
 @app.route('/')
 def home():
     races = get_races()
-    default_race = races[0] if races else None
+    default_race = pick_default_race(races)
 
-    if default_race:
-        # Redirect to the default race using the new results route
-        race_name = to_url_friendly_name(default_race['name'])
-        return redirect(url_for('redirect_to_results', race_name=race_name))
-    else:
-        # No races available, show empty page or error
+    if not default_race:
         return render_template('index.html',
                              page_title='Long-Course Age Graded Results',
                              races=[],
                              selected_race='')
+
+    race_name = request.args.get('race') or to_url_friendly_name(default_race['name'])
+    selected_race = get_race_by_name(race_name) or default_race
+    selected_source_arg = request.args.get('source')
+    selected_gender_arg = request.args.get('gender')
+
+    normalized = normalize_selection(selected_race, selected_source_arg, selected_gender_arg)
+    source = normalized['source']
+    gender = normalized['gender']
+
+    iframe_state = build_iframe_state(selected_race, source, gender)
+    slot_summary = compute_slot_summary(selected_race, gender)
+    current_races, archive_races = partition_races_for_controls(races)
+    current_races = [
+        {**race, "control_label": format_current_race_label(race.get("name", ""))}
+        for race in current_races
+    ]
+
+    return render_template(
+        'index.html',
+        page_title='Long-Course Age Graded Results',
+        races=races,
+        current_races=current_races,
+        archive_races=archive_races,
+        selected_race=selected_race['name'],
+        selected_source=source,
+        selected_gender=gender,
+        iframe_url=iframe_state['iframe_url'],
+        coming_soon=iframe_state['coming_soon'],
+        slot_summary=slot_summary
+    )
 
 @app.route('/about')
 def about():
@@ -299,90 +500,21 @@ def redirect_to_results(race_name):
 
     if not race:
         abort(404)
-
-    # Determine availability of official_ag results
-    has_official_ag = False
-    if 'results_urls' in race and 'official_ag' in race['results_urls']:
-        if race['distance'] == '70.3':
-            has_official_ag = bool(race['results_urls']['official_ag'].get('men'))
-        else:  # 140.6
-            has_official_ag = bool(race['results_urls']['official_ag'])
-
-    # Default to Live for future races and within initial post-start windows:
-    # - Future (before earliestStartTime): Live
-    # - 140.6: first 16 hours after earliestStartTime: Live
-    # - 70.3: first 8 hours after earliestStartTime: Live
-    earliest_start = int(race.get('earliestStartTime', 0) or 0)
-    now_ts = int(datetime.now().timestamp())
-    within_window = False
-    if earliest_start > 0:
-        if now_ts < earliest_start:
-            # Race hasn't started yet; default to Live
-            policy = resolve_slot_policy(race)
-            if policy_needs_gender(policy):
-                default_gender = choose_default_gender(race)
-                return redirect(url_for('display_results', race_name=race_name, data_source='live', gender=default_gender))
-            else:
-                return redirect(url_for('display_results', race_name=race_name, data_source='live'))
-        else:
-            window_hours = 16 if race['distance'] == '140.6' else 8
-            within_window = now_ts < (earliest_start + window_hours * 3600)
-
-    # Decide data_source with new default rules
-    if within_window:
-        policy = resolve_slot_policy(race)
-        if policy_needs_gender(policy):
-            default_gender = choose_default_gender(race)
-            return redirect(url_for('display_results', race_name=race_name, data_source='live', gender=default_gender))
-        else:
-            return redirect(url_for('display_results', race_name=race_name, data_source='live'))
-
-    # Outside the window: prefer official if available, else live
-    policy = resolve_slot_policy(race)
-    if policy_needs_gender(policy):
-        default_gender = choose_default_gender(race)
-        return redirect(url_for('display_results', race_name=race_name, data_source='official_ag' if has_official_ag else 'live', gender=default_gender))
-    else:
-        return redirect(url_for('display_results', race_name=race_name, data_source='official_ag' if has_official_ag else 'live'))
+    normalized = normalize_selection(race)
+    canonical = build_canonical_url(race_name, normalized['source'], normalized['gender'])
+    return redirect(canonical, code=302)
 
 @app.route('/results/<race_name>/<data_source>')
 @app.route('/results/<race_name>/<data_source>/<gender>')
 def display_results(race_name, data_source, gender=None):
-    races = get_races()
     race = get_race_by_name(race_name)
 
     if not race:
         abort(404)
 
-    iframe_url = None
-    coming_soon = True
-
-    if data_source == 'official_ag':
-        if 'official_ag' in race.get('results_urls', {}):
-            official = race['results_urls']['official_ag']
-            if race['distance'] == '70.3' and gender and isinstance(official, dict):
-                iframe_url = official.get(gender) or ""
-            elif race['distance'] == '140.6':
-                if isinstance(official, dict) and gender:
-                    iframe_url = official.get(gender) or ""
-                elif isinstance(official, str):
-                    iframe_url = official
-            coming_soon = bool(iframe_url)
-
-    # Provide slot summary on official results pages as well
-    slot_summary = compute_slot_summary(race, gender) if race else None
-
-    return render_template(
-        'index.html',
-        page_title='Long-Course Age Graded Results',
-        races=races,
-        selected_race=from_url_friendly_name(race_name),
-        selected_source=data_source,
-        selected_gender=gender,
-        iframe_url=iframe_url,
-        coming_soon=coming_soon,
-        slot_summary=slot_summary
-    )
+    normalized = normalize_selection(race, data_source, gender)
+    canonical = build_canonical_url(race_name, normalized['source'], normalized['gender'])
+    return redirect(canonical, code=302)
 
 def get_race_status_message(race):
     """
@@ -558,6 +690,10 @@ def live_results_table(race_name, gender=None):
     if not race:
         return jsonify({"error": "Race not found"}), 404
 
+    selected_theme = request.args.get('theme')
+    if selected_theme not in ('light', 'dark'):
+        selected_theme = None
+
     # Determine gender and adjustments based on slot policy
     policy = resolve_slot_policy(race)
     if policy_needs_gender(policy):
@@ -585,7 +721,7 @@ def live_results_table(race_name, gender=None):
     # Check if we should fetch results based on race timing
     message, should_fetch_results = get_race_status_message(race)
     if not should_fetch_results:
-        return render_template('live_results.html', results=[], error=message, slot_summary=slot_summary)
+        return render_template('live_results.html', results=[], error=message, slot_summary=slot_summary, selected_theme=selected_theme)
 
     # Use caching-aware retrieval to reduce load on RTRT servers
     processed_data = parse_live_data.get_processed_results_cached(race, gender, ag_adjustments)
@@ -597,9 +733,9 @@ def live_results_table(race_name, gender=None):
                 'text': "No racers have crossed the finish line yet. Results will appear here as soon as racers finish.",
                 'timestamp': None
             }
-            return render_template('live_results.html', results=[], error=message)
+            return render_template('live_results.html', results=[], error=message, selected_theme=selected_theme)
         else:
-            return render_template('live_results.html', results=[], error=processed_data["error"])
+            return render_template('live_results.html', results=[], error=processed_data["error"], selected_theme=selected_theme)
 
     # Annotate slot allocation including dynamic logic
     try:
@@ -607,7 +743,7 @@ def live_results_table(race_name, gender=None):
     except Exception as e:
         current_app.logger.warning(f"Slot allocation annotation failed: {e}")
 
-    return render_template('live_results.html', results=processed_data, slot_summary=slot_summary)
+    return render_template('live_results.html', results=processed_data, slot_summary=slot_summary, selected_theme=selected_theme)
 
 @app.route('/fragment/slot_summary/<race_name>')
 def fragment_slot_summary(race_name):

--- a/docs/ui_touchpoints.md
+++ b/docs/ui_touchpoints.md
@@ -1,0 +1,10 @@
+# UI State Touchpoints
+
+This document maps the primary files that participate in the home-page rendering and state flow.
+
+- `app.py`: canonical state normalization, route compatibility, and default race/source/gender selection.
+- `templates/index.html`: control surface (race, data source, gender), slot summary mount, and results iframe container.
+- `static/js/home.js`: client state transitions, canonical query URL sync, popstate handling, and searchable race input wiring.
+- `templates/partials/nav.html`: Home navigation and theme toggle mount.
+- `static/js/nav.js`: dark-mode persistence and nav menu behavior.
+- `static/css/styles.css`: tokenized theme palette, component surfaces, and responsive layout styles.

--- a/docs/ui_verification_checklist.md
+++ b/docs/ui_verification_checklist.md
@@ -1,0 +1,24 @@
+# UI Redesign Verification Checklist
+
+## Route and URL Behavior
+- [ ] `GET /` returns `200` and does not redirect.
+- [ ] `GET /?race=<slug>&source=<source>[&gender=<gender>]` hydrates matching UI state.
+- [ ] Legacy routes `/results/<race>[/<source>[/<gender>]]` redirect to canonical query URLs.
+
+## State Interaction
+- [ ] Race changes re-evaluate source availability and gender requirements.
+- [ ] Browser Back/Forward restores state via `popstate`.
+- [ ] Canonical URL updates on user interaction and is shareable.
+
+## Searchable Race Picker
+- [ ] Typing a race label updates selection on `change` / `Enter`.
+- [ ] Picker selection updates race state, iframe source, and query URL.
+
+## Visual and Accessibility
+- [ ] Theme toggle switches between light/dark and persists across reloads.
+- [ ] Core controls are keyboard focusable and have visible labels.
+- [ ] Contrast in both themes remains readable for body text and controls.
+
+## Regression
+- [ ] Existing slot summary rendering still works after race/source/gender changes.
+- [ ] Live results and official iframe loading behavior still works for 70.3 and 140.6 race shapes.

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,8 +1,52 @@
+:root {
+    color-scheme: light;
+    --bg: #f5f7fb;
+    --surface: #ffffff;
+    --surface-muted: #eef2f8;
+    --text: #1f2937;
+    --text-soft: #4b5563;
+    --border: #d6dee9;
+    --accent: #2563eb;
+    --accent-soft: #dbeafe;
+    --shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+    --loading-overlay: rgba(241, 245, 249, 0.72);
+    --spinner-track: rgba(37, 99, 235, 0.22);
+    --spinner-head: #2563eb;
+    --chip-ag-bg: #e8f5e9;
+    --chip-ag-border: #7dbb88;
+    --chip-ag-text: #1f5f2d;
+    --chip-pool-bg: #fff3db;
+    --chip-pool-border: #d7b36d;
+    --chip-pool-text: #6b4200;
+}
+
+html[data-theme="dark"] {
+    color-scheme: dark;
+    --bg: #0b1220;
+    --surface: #111a2d;
+    --surface-muted: #16233b;
+    --text: #e5e7eb;
+    --text-soft: #cbd5e1;
+    --border: #2a3a56;
+    --accent: #60a5fa;
+    --accent-soft: #1e3a5f;
+    --shadow: 0 14px 32px rgba(2, 8, 23, 0.45);
+    --loading-overlay: rgba(10, 16, 30, 0.58);
+    --spinner-track: rgba(148, 163, 184, 0.24);
+    --spinner-head: #60a5fa;
+    --chip-ag-bg: #20452f;
+    --chip-ag-border: #3d7b5a;
+    --chip-ag-text: #d3f4df;
+    --chip-pool-bg: #4f3e17;
+    --chip-pool-border: #83662a;
+    --chip-pool-text: #ffe5a7;
+}
+
 /* Basic styling for the body and fonts */
 body {
     font-family: Arial, sans-serif;
-    background-color: #f4f7f9;
-    color: #333;
+    background-color: var(--bg);
+    color: var(--text);
     line-height: 1.6;
     margin: 0;
     padding: 0;
@@ -13,25 +57,20 @@ body {
     margin-bottom: 15px;
 }
 
-.selection-group:first-of-type {
-    min-width: 250px;
-    max-width: 100%;
-}
-
 /* Slots information styling */
 .slots-info {
     display: block;
     margin-top: 8px;
     padding: 6px 12px;
-    background-color: #f9f9f9;
-    border: 1px solid #e0e0e0;
+    background-color: var(--surface-muted);
+    border: 1px solid var(--border);
     border-radius: 4px;
     font-size: 0.9em;
-    color: #333;
+    color: var(--text);
     max-width: 100%;
 }
 .slots-info strong {
-    color: #e74c3c;
+    color: var(--accent);
     font-weight: 600;
 }
 
@@ -103,7 +142,7 @@ body {
 .hamburger {
     width: 30px;
     height: 3px;
-    background-color: #333;
+    background-color: var(--text);
     position: relative;
     transition: all 0.3s ease-in-out;
     display: block;
@@ -115,7 +154,7 @@ body {
     position: absolute;
     width: 100%;
     height: 3px;
-    background-color: #333;
+    background-color: var(--text);
     left: 0;
     transition: all 0.3s ease-in-out;
 }
@@ -142,7 +181,7 @@ body {
 }
 
 .nav-menu {
-    background-color: #ffffff;
+    background-color: var(--surface);
     padding: 10px 0;
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
     margin-bottom: 20px;
@@ -163,7 +202,7 @@ body {
 }
 
 .nav-menu a {
-    color: #333;
+    color: var(--text);
     text-decoration: none;
     font-size: 1.1em;
     font-weight: 500;
@@ -171,7 +210,7 @@ body {
 }
 
 .nav-menu a:hover {
-    color: #e74c3c;
+    color: var(--accent);
 }
 
 /* Mobile styles */
@@ -227,17 +266,17 @@ body {
 .container {
     max-width: 800px;
     margin: 20px auto;
-    background-color: #ffffff;
+    background-color: var(--surface);
     padding: 30px;
     border-radius: 10px;
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--shadow);
 }
 
 /* Heading styles */
 h1 {
     font-size: 2.5em; /* Changed to match "Coming Soon!" message */
     font-weight: bold;
-    color: #2c3e50;
+    color: var(--text);
     text-align: center;
     border-bottom: none; /* Removed the border-bottom */
     padding-bottom: 0;
@@ -246,52 +285,88 @@ h1 {
 
 /* A new class for the gradient background for just the controls */
 .controls-container {
-    background: linear-gradient(to right, #e74c3c, #000000);
-    color: #ffffff;
+    background: var(--surface-muted);
+    color: var(--text);
     padding: 20px;
-    border-radius: 8px;
+    border-radius: 12px;
+    border: 1px solid var(--border);
     margin-bottom: 20px;
 }
 
 /* Styles for text and form elements inside the gradient container */
 .controls-container p,
 .controls-container label {
-    color: #ffffff;
+    color: var(--text);
 }
 
 select {
     width: 100%;
     padding: 12px;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border);
     border-radius: 5px;
     font-size: 16px;
     box-sizing: border-box;
-    background-color: #f9f9f9;
-    color: #333;
+    background-color: var(--surface);
+    color: var(--text);
+}
+
+#race-search {
+    width: 100%;
+    padding: 12px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    font-size: 15px;
+    box-sizing: border-box;
+    margin-bottom: 0;
+    background: var(--surface);
+    color: var(--text);
+}
+
+/* Keep native select for app state wiring, but show only searchable input UI. */
+#race-select {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+    width: 1px;
+    height: 1px;
 }
 
 /* The rest of your styles from before */
 form {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 16px;
     margin-bottom: 20px;
+    align-items: stretch;
 }
 
 .selection-group {
-    flex: 1;
-    min-width: 200px;
-    margin-right: 20px;
-    /* Use Flexbox to align content */
+    min-width: 0;
+    margin-right: 0;
     display: flex;
     flex-direction: column;
+    gap: 10px;
+}
+
+.control-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+    position: relative;
+}
+
+.control-title {
+    margin: 0;
+    font-size: 1.05rem;
+    line-height: 1.2;
+    color: var(--text);
 }
 
 .selection-group label {
     font-weight: bold;
-    color: #ffffff;
-    margin-bottom: 8px;
+    color: var(--text);
+    margin-bottom: 0;
 }
 
 .selection-group p {
@@ -299,11 +374,138 @@ form {
     margin-bottom: 5px;
 }
 
-.selection-group label.radio-label {
-    font-weight: normal;
-    display: inline-block;
-    margin-right: 15px;
-    margin-bottom: 5px;
+.choice-option {
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.race-combobox {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px;
+}
+
+.archive-dropdown {
+    position: relative;
+}
+
+#race-dropdown-toggle {
+    min-width: 42px;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    background: var(--surface-muted);
+    color: var(--text);
+    cursor: pointer;
+}
+
+.race-options {
+    display: flex;
+    flex-direction: column;
+    max-height: 240px;
+    overflow-y: auto;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface);
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: calc(100% + 8px);
+    z-index: 15;
+    box-shadow: var(--shadow);
+}
+
+.race-option-item {
+    text-align: left;
+    border: 0;
+    border-bottom: 1px solid var(--border);
+    background: transparent;
+    color: var(--text);
+    padding: 10px 12px;
+    cursor: pointer;
+}
+
+.race-option-item:last-child {
+    border-bottom: 0;
+}
+
+.race-option-item:hover {
+    background: var(--surface-muted);
+}
+
+.race-option-empty {
+    color: var(--text-soft);
+    padding: 10px 12px;
+}
+
+.current-races-panel {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface-muted);
+    padding: 8px;
+}
+
+.current-races-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.88rem;
+    color: var(--text-soft);
+    margin-bottom: 8px;
+}
+
+#current-races-count {
+    font-weight: 700;
+}
+
+.current-race-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.current-race-btn {
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    border-radius: 999px;
+    padding: 6px 10px;
+    cursor: pointer;
+    font-size: 0.88rem;
+    width: 100%;
+    text-align: center;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    text-overflow: clip;
+    max-width: 100%;
+    line-height: 1.2;
+}
+
+.current-race-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.current-race-btn.active {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-weight: 700;
+}
+
+.current-races-panel.collapsed .current-race-buttons {
+    display: none;
+}
+
+.current-races-header {
+    cursor: pointer;
+}
+
+.archive-header {
+    font-size: 0.86rem;
+    font-weight: 700;
+    color: var(--text-soft);
 }
 
 /* New style for disabled controls */
@@ -336,13 +538,14 @@ form {
     left: 0;
     width: 100%;
     height: 100%;
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--loading-overlay);
+    backdrop-filter: blur(1px);
     z-index: 1000;
 }
 
 .spinner {
-    border: 8px solid rgba(231, 76, 60, 0.3); /* Match gradient color */
-    border-top: 8px solid #e74c3c; /* Match gradient color */
+    border: 8px solid var(--spinner-track);
+    border-top: 8px solid var(--spinner-head);
     border-radius: 50%;
     width: 60px;
     height: 60px;
@@ -365,20 +568,22 @@ form {
 }
 
 .results-table th, .results-table td {
-    border: 1px solid #ddd;
+    border: 1px solid var(--border);
     padding: 8px;
     text-align: left;
+    background-color: var(--surface);
+    color: var(--text);
 }
 
 .results-table th {
-    background-color: #f2f2f2;
+    background-color: var(--surface-muted);
     font-weight: bold;
     cursor: pointer;
     user-select: none;
 }
 
 .results-table th:hover {
-    background-color: #e0e0e0;
+    background-color: var(--accent-soft);
 }
 
 .results-table th.sorted-asc::after {
@@ -403,13 +608,13 @@ form {
 
 .message-text {
     margin-bottom: 0.5em;
-    color: #333;
+    color: var(--text);
 }
 
 .message-datetime {
     font-size: 1.4em;
     font-weight: bold;
-    color: #8B2635;
+    color: var(--accent);
     margin-top: 0.5em;
 }
 
@@ -426,7 +631,7 @@ form {
     left: 0;
     width: 100%;
     height: 100%;
-    background: rgba(255, 255, 255, 0.8);
+    background: var(--loading-overlay);
     z-index: 1000;
 }
 
@@ -441,11 +646,11 @@ form {
 /* Rolldown message styles */
 .rolldown-message {
     display: none;
-    background-color: #f8f9fa;
+    background-color: var(--surface-muted);
     padding: 10px;
     margin-bottom: 15px;
     border-radius: 5px;
-    border: 1px solid #dee2e6;
+    border: 1px solid var(--border);
 }
 
 /* Message area styles */
@@ -457,7 +662,7 @@ form {
 #results-iframe {
     width: 100%;
     min-height: 500px;
-    border: 1px solid #ddd;
+    border: 1px solid var(--border);
     border-radius: 8px;
     box-shadow: 0 2px 5px rgba(0,0,0,0.05);
 }
@@ -466,7 +671,34 @@ form {
 .rolldown-content-text {
     margin: 0;
     font-style: italic;
-    color: #6c757d;
+    color: var(--text-soft);
+}
+
+.page-header {
+    margin-bottom: 18px;
+}
+
+.page-subtitle {
+    margin-top: -6px;
+    color: var(--text-soft);
+}
+
+.theme-toggle {
+    position: fixed;
+    top: 16px;
+    left: 16px;
+    z-index: 1001;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--surface);
+    color: var(--text);
+    padding: 6px 12px;
+    cursor: pointer;
+}
+
+.theme-toggle:hover {
+    border-color: var(--accent);
+    color: var(--accent);
 }
 
 /* Rolldowns page specific styles */
@@ -619,19 +851,39 @@ form {
     background-color: #fff9e6; /* light yellow */
 }
 
+.row-ag-winner td {
+    background-color: rgba(40, 167, 69, 0.16);
+    color: #1f5f2d;
+}
+
+.row-pool-qualifier td {
+    background-color: rgba(255, 193, 7, 0.16);
+    color: #6b4200;
+}
+
+html[data-theme="dark"] .row-ag-winner td {
+    background-color: #b6d9bf;
+    color: #173a20;
+}
+
+html[data-theme="dark"] .row-pool-qualifier td {
+    background-color: #eadcb7;
+    color: #3f2a00;
+}
+
 /* ====== Live results template extracted styles ====== */
 .disclaimer {
-    background-color: #f8f9fa;
+    background-color: var(--surface-muted);
     padding: 10px;
     margin-bottom: 15px;
     border-radius: 5px;
-    border: 1px solid #dee2e6;
+    border: 1px solid var(--border);
 }
 
 .disclaimer p {
     margin: 0;
     font-style: italic;
-    color: #6c757d;
+    color: var(--text-soft);
 }
 
 .highlight-controls {
@@ -659,20 +911,20 @@ form {
 }
 
 .toggle-ag {
-    background: #eaf7ea;
-    border: 1px solid #cde8cd;
-    color: #1b5e20;
+    background: var(--chip-ag-bg);
+    border: 1px solid var(--chip-ag-border);
+    color: var(--chip-ag-text);
 }
 
 .toggle-pool {
-    background: #fff9e6;
-    border: 1px solid #ffe8a3;
-    color: #8a6d3b;
+    background: var(--chip-pool-bg);
+    border: 1px solid var(--chip-pool-border);
+    color: var(--chip-pool-text);
 }
 
 .highlight-disclaimer {
     font-size: 0.95em;
-    color: #6c757d;
+    color: var(--text-soft);
     font-style: italic;
 }
 
@@ -687,8 +939,8 @@ form {
 
 /* Slot summary panel */
 .slot-summary {
-    background-color: #ffffff;
-    border: 1px solid #e5e7eb;
+    background-color: var(--surface);
+    border: 1px solid var(--border);
     border-radius: 8px;
     padding: 12px 16px;
     margin: 10px 0 15px 0;
@@ -696,7 +948,7 @@ form {
 .slot-summary h3 {
     margin: 0 0 8px 0;
     font-size: 1.1em;
-    color: #2c3e50;
+    color: var(--text);
 }
 .slot-summary-header {
     display: flex;
@@ -709,12 +961,12 @@ form {
     border-radius: 6px;
 }
 .slot-summary-header:hover {
-    background: #f3f4f6;
+    background: var(--surface-muted);
 }
 .slot-summary-title {
     font-size: 1.05em;
     font-weight: 600;
-    color: #2c3e50;
+    color: var(--text);
     display: flex;
     align-items: center;
     gap: 6px;
@@ -726,7 +978,7 @@ form {
     align-items: center;
     justify-content: center;
     font-size: 14px;
-    color: #374151;
+    color: var(--text-soft);
     transition: transform .2s ease;
 }
 .slot-summary .slot-summary-toggle-icon { transform: rotate(90deg); }
@@ -735,7 +987,7 @@ form {
 .slot-summary.collapsed .slot-summary-content { display: none; }
 .slot-summary-mini {
     font-size: 0.75rem;
-    color: #4b5563;
+    color: var(--text-soft);
     font-weight: 600;
     display: none;
     gap: 8px;
@@ -749,12 +1001,12 @@ form {
     letter-spacing: .5px;
     padding: 2px 6px;
     border-radius: 10px;
-    background: #eef2f7;
-    color: #374151;
+    background: var(--surface-muted);
+    color: var(--text-soft);
     text-transform: uppercase;
 }
-.slot-summary-status-pill.waiting { background: #fff3cd; color: #8a6d3b; }
-.slot-summary-status-pill.ready { background: #eaf7ea; color: #1b5e20; }
+.slot-summary-status-pill.waiting { background: var(--chip-pool-bg); color: var(--chip-pool-text); }
+.slot-summary-status-pill.ready { background: var(--chip-ag-bg); color: var(--chip-ag-text); }
 .slot-stats {
     display: grid;
     gap: 8px 16px;
@@ -766,39 +1018,43 @@ form {
     grid-template-columns: 1fr 1fr;
 }
 .slot-stats .label {
-    color: #6b7280;
+    color: var(--text-soft);
     margin-right: 6px;
 }
 .slot-stats .value {
     font-weight: 700;
-    color: #111827;
+    color: var(--text);
 }
 .slot-stats .value.pending {
-    color: #9ca3af;
+    color: var(--text-soft);
     font-style: italic;
 }
 .gender-col {
-    background: #f9fafb;
-    border: 1px solid #eef2f7;
+    background: var(--surface-muted);
+    border: 1px solid var(--border);
     border-radius: 6px;
     padding: 10px 12px;
 }
 .gender-title {
     font-weight: 700;
-    color: #374151;
+    color: var(--text);
     margin-bottom: 6px;
 }
 .slot-waiting {
     margin: 8px 0 10px 0;
     padding: 8px 12px;
-    background: #fff9e6;
-    border: 1px solid #ffe8a3;
+    background: var(--chip-pool-bg);
+    border: 1px solid var(--chip-pool-border);
     border-radius: 6px;
-    color: #8a6d3b;
+    color: var(--chip-pool-text);
 }
 
 /* Responsive design for rolldown columns */
 @media (max-width: 768px) {
+    form {
+        grid-template-columns: 1fr;
+    }
+
     .rolldown-columns {
         grid-template-columns: 1fr;
         gap: 1rem;

--- a/static/js/home.js
+++ b/static/js/home.js
@@ -1,0 +1,535 @@
+function parsePageConfig() {
+  const node = document.getElementById("page-config");
+  if (!node) return { races: [] };
+  try {
+    return JSON.parse(node.textContent || "{}");
+  } catch (_) {
+    return { races: [] };
+  }
+}
+
+function setupTooltip(tooltipContainer) {
+  const icon = tooltipContainer.querySelector(".tooltip-icon");
+  if (!icon) return;
+  icon.addEventListener("click", (e) => {
+    e.stopPropagation();
+    document.querySelectorAll(".tooltip.active").forEach((tooltip) => {
+      if (tooltip !== tooltipContainer) tooltip.classList.remove("active");
+    });
+    tooltipContainer.classList.toggle("active");
+  });
+}
+
+function slugifyRace(name) {
+  return (name || "").replace(/ /g, "_");
+}
+
+document.addEventListener("click", (e) => {
+  if (!e.target.closest(".tooltip")) {
+    document.querySelectorAll(".tooltip.active").forEach((tooltip) => tooltip.classList.remove("active"));
+  }
+});
+
+document.addEventListener("DOMContentLoaded", () => {
+  const config = parsePageConfig();
+  const racesData = config.races || [];
+  const currentRaceNames = new Set(config.currentRaceNames || []);
+
+  const raceSelect = document.getElementById("race-select");
+  const raceSearch = document.getElementById("race-search");
+  const raceOptions = document.getElementById("race-options");
+  const raceDropdownToggle = document.getElementById("race-dropdown-toggle");
+  const currentRacesPanel = document.getElementById("current-races-panel");
+  const currentRaceButtons = document.getElementById("current-race-buttons");
+  const currentRacesHeader = document.getElementById("current-races-header");
+  const sourceRadios = Array.from(document.querySelectorAll('input[name="data_source"]'));
+  const genderRadios = Array.from(document.querySelectorAll('input[name="gender"]'));
+  const genderDiv = document.getElementById("gender-selection");
+  const iframe = document.getElementById("results-iframe");
+  const messageArea = document.getElementById("message-area");
+  const loadingOverlay = document.getElementById("loading-overlay");
+  const officialAgRadio = document.querySelector('input[name="data_source"][value="official_ag"]');
+  const liveRadio = document.querySelector('input[name="data_source"][value="live"]');
+
+  let hasUserInteracted = false;
+
+  function findRaceData(raceName) {
+    return racesData.find((race) => race.name === raceName);
+  }
+
+  function currentRaceOption() {
+    return raceSelect.options[raceSelect.selectedIndex] || null;
+  }
+
+  function isCurrentRace(name) {
+    return currentRaceNames.has(name);
+  }
+
+  function setCurrentRacesCollapsed(collapsed) {
+    if (!currentRacesPanel) return;
+    currentRacesPanel.classList.toggle("collapsed", collapsed);
+    if (currentRacesHeader) {
+      currentRacesHeader.setAttribute("aria-expanded", collapsed ? "false" : "true");
+    }
+  }
+
+  function updateCurrentRaceSelectionUI(selectedName) {
+    if (!currentRaceButtons) return;
+    currentRaceButtons.querySelectorAll(".current-race-btn").forEach((btn) => {
+      btn.classList.toggle("active", btn.getAttribute("data-race-name") === selectedName);
+    });
+  }
+
+  function setRaceSearchToSelected() {
+    const option = currentRaceOption();
+    if (!raceSearch || !option) return;
+    raceSearch.value = option.getAttribute("data-race-label") || option.textContent.trim();
+  }
+
+  function closeRaceOptions() {
+    if (!raceOptions || !raceDropdownToggle) return;
+    raceOptions.classList.add("hidden");
+    raceDropdownToggle.setAttribute("aria-expanded", "false");
+  }
+
+  function openRaceOptions() {
+    if (!raceOptions || !raceDropdownToggle) return;
+    raceOptions.classList.remove("hidden");
+    raceDropdownToggle.setAttribute("aria-expanded", "true");
+  }
+
+  function selectRaceValue(value, pushHistory = true) {
+    if (!value) return false;
+    const next = Array.from(raceSelect.options).find((option) => option.value === value);
+    if (!next) return false;
+    raceSelect.value = next.value;
+    updateCurrentRaceSelectionUI(next.value);
+    if (isCurrentRace(next.value)) {
+      raceSearch.value = "";
+      setCurrentRacesCollapsed(false);
+    } else {
+      setRaceSearchToSelected();
+      setCurrentRacesCollapsed(true);
+    }
+    hasUserInteracted = pushHistory;
+    updateAll(pushHistory);
+    return true;
+  }
+
+  function renderRaceOptions(filterText = "") {
+    if (!raceOptions) return;
+    const normalized = (filterText || "").trim().toLowerCase();
+    const entries = Array.from(raceSelect.options).filter((option) => {
+      if (isCurrentRace(option.value)) return false;
+      const label = (option.getAttribute("data-race-label") || option.textContent || "").toLowerCase();
+      return !normalized || label.includes(normalized);
+    });
+    raceOptions.innerHTML = "";
+
+    if (!entries.length) {
+      const empty = document.createElement("div");
+      empty.className = "race-option-empty";
+      empty.textContent = "No races match your search";
+      raceOptions.appendChild(empty);
+      return;
+    }
+
+    entries.forEach((option) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "race-option-item";
+      button.setAttribute("role", "option");
+      button.textContent = option.getAttribute("data-race-label") || option.textContent.trim();
+      button.addEventListener("click", () => {
+        selectRaceValue(option.value, true);
+        closeRaceOptions();
+      });
+      raceOptions.appendChild(button);
+    });
+  }
+
+  function officialAvailable(race) {
+    if (!race || !race.results_urls || !("official_ag" in race.results_urls)) return false;
+    if (race.distance === "70.3") {
+      const men = race.results_urls.official_ag?.men ?? "";
+      const women = race.results_urls.official_ag?.women ?? "";
+      return Boolean((men && men.trim()) || (women && women.trim()));
+    }
+    const url = race.results_urls.official_ag;
+    if (typeof url === "string") return Boolean(url.trim());
+    if (typeof url === "object" && url !== null) {
+      const men = url.men ?? "";
+      const women = url.women ?? "";
+      return Boolean((men && men.trim()) || (women && women.trim()));
+    }
+    return false;
+  }
+
+  function officialGendered(race, source) {
+    const officialAg = race.results_urls?.official_ag;
+    return (
+      source === "official_ag" &&
+      race.distance === "140.6" &&
+      typeof officialAg === "object" &&
+      officialAg !== null &&
+      ((officialAg.men && officialAg.men.trim()) || (officialAg.women && officialAg.women.trim()))
+    );
+  }
+
+  async function refreshSlotSummary(race, gender) {
+    try {
+      const name = slugifyRace(race?.name || "");
+      if (!name) return;
+      const params = new URLSearchParams();
+      if (gender) params.set("gender", gender);
+      const res = await fetch(`/fragment/slot_summary/${name}?${params.toString()}`);
+      if (!res.ok) return;
+      const html = await res.text();
+      const container = document.getElementById("slot-summary-container");
+      if (!container) return;
+      container.innerHTML = html;
+
+      const scripts = Array.from(container.querySelectorAll("script"));
+      scripts.forEach((oldScript) => {
+        const s = document.createElement("script");
+        for (const attr of oldScript.attributes) s.setAttribute(attr.name, attr.value);
+        s.text = oldScript.textContent || "";
+        document.body.appendChild(s);
+        oldScript.remove();
+      });
+    } catch (_) {}
+  }
+
+  function updateRolldownInfo(source, race) {
+    const rolldownDiv = document.getElementById("rolldown-info");
+    const rolldownContent = document.getElementById("rolldown-content");
+    if (!rolldownDiv || !rolldownContent) return;
+
+    if (source !== "official_ag" || !race) {
+      rolldownDiv.style.display = "none";
+      return;
+    }
+
+    let rolldownPosition = null;
+    if (race.known_rolldown) {
+      if (race.distance === "70.3") {
+        const selectedGender = document.querySelector('input[name="gender"]:checked')?.value;
+        if (selectedGender && race.known_rolldown[selectedGender]) rolldownPosition = race.known_rolldown[selectedGender];
+      } else if (race.distance === "140.6" && typeof race.known_rolldown === "number") {
+        rolldownPosition = race.known_rolldown;
+      }
+    }
+
+    if (rolldownPosition) {
+      rolldownContent.innerHTML = `<span class="rolldown-content-text"><strong>Performance Pool Info</strong>: The performance pool rolled down to at least position <strong>${rolldownPosition}</strong>.</span>`;
+    } else {
+      rolldownContent.innerHTML = `<p class="rolldown-content-text"><strong>Performance Pool Info</strong>: No confirmed performance pool depth is recorded for this race yet.</p>`;
+    }
+    rolldownDiv.style.display = "block";
+  }
+
+  function showLoading() {
+    loadingOverlay.style.display = "block";
+    iframe.style.display = "none";
+    messageArea.style.display = "none";
+  }
+
+  function getCurrentTheme() {
+    const theme = document.documentElement.getAttribute("data-theme");
+    return theme === "dark" || theme === "light" ? theme : null;
+  }
+
+  function notifyLiveIframeTheme() {
+    const theme = getCurrentTheme();
+    if (!theme || !iframe || !iframe.src || !iframe.src.includes("/live_results/")) return;
+    if (iframe.contentWindow) {
+      iframe.contentWindow.postMessage({ type: "canikona:set-theme", theme }, window.location.origin);
+    }
+  }
+
+  function attachIframeLoadHandler() {
+    iframe.onload = () => {
+      hideLoading();
+      notifyLiveIframeTheme();
+    };
+  }
+
+  function applyThemeParamToLiveIframe() {
+    if (!iframe || !iframe.src || !iframe.src.includes("/live_results/")) return;
+    const currentTheme = getCurrentTheme();
+    if (currentTheme !== "dark" && currentTheme !== "light") return;
+    const iframeUrl = new URL(iframe.src, window.location.origin);
+    iframeUrl.searchParams.set("theme", currentTheme);
+    iframe.src = iframeUrl.pathname + iframeUrl.search;
+  }
+
+  function hideLoading() {
+    loadingOverlay.style.display = "none";
+  }
+
+  function writeCanonicalQuery(race, source, gender) {
+    if (!race) return;
+    const params = new URLSearchParams();
+    params.set("race", slugifyRace(race.name));
+    params.set("source", source);
+    if (gender) params.set("gender", gender);
+    const next = `/?${params.toString()}`;
+    if (hasUserInteracted) {
+      window.history.pushState({}, "", next);
+    } else {
+      window.history.replaceState({}, "", next);
+    }
+  }
+
+  function syncFromUrl(search) {
+    const params = new URLSearchParams(search);
+    const raceSlug = params.get("race");
+    const source = params.get("source");
+    const gender = params.get("gender");
+    const race = racesData.find((r) => slugifyRace(r.name) === raceSlug);
+    if (!race) return;
+
+    raceSelect.value = race.name;
+    updateCurrentRaceSelectionUI(race.name);
+    if (isCurrentRace(race.name)) {
+      raceSearch.value = "";
+      setCurrentRacesCollapsed(false);
+    } else {
+      setRaceSearchToSelected();
+      setCurrentRacesCollapsed(true);
+    }
+    if (source === "official_ag" || source === "live") {
+      const sourceInput = document.querySelector(`input[name="data_source"][value="${source}"]`);
+      if (sourceInput) sourceInput.checked = true;
+    }
+    if (gender === "men" || gender === "women") {
+      const genderInput = document.querySelector(`input[name="gender"][value="${gender}"]`);
+      if (genderInput) genderInput.checked = true;
+    }
+    updateAll(false);
+  }
+
+  function updateSourceAvailability(race) {
+    const hasOfficialAg = officialAvailable(race);
+    officialAgRadio.disabled = !hasOfficialAg;
+    officialAgRadio.parentElement.classList.toggle("disabled-controls", !hasOfficialAg);
+    liveRadio.disabled = false;
+    liveRadio.parentElement.classList.remove("disabled-controls");
+    if (!hasOfficialAg && officialAgRadio.checked) {
+      liveRadio.checked = true;
+    }
+  }
+
+  function updateGenderAvailability(race, source) {
+    const slotPolicy = race.slot_policy || "";
+    const isSplit = slotPolicy.startsWith("split");
+    const allowGender = isSplit || officialGendered(race, source);
+
+    if (allowGender) {
+      genderDiv.classList.remove("disabled-controls");
+      genderRadios.forEach((radio) => {
+        radio.disabled = false;
+      });
+      const checked = document.querySelector('input[name="gender"]:checked');
+      if (!checked) {
+        const menRadio = document.querySelector('input[name="gender"][value="men"]');
+        if (menRadio) menRadio.checked = true;
+      }
+    } else {
+      genderDiv.classList.add("disabled-controls");
+      genderRadios.forEach((radio) => {
+        radio.disabled = true;
+      });
+    }
+    return allowGender;
+  }
+
+  async function updateAll(pushHistory = true) {
+    const selectedRaceName = raceSelect.value;
+    const race = findRaceData(selectedRaceName);
+    if (!race) return;
+    updateSourceAvailability(race);
+    const source = document.querySelector('input[name="data_source"]:checked').value;
+    const allowGender = updateGenderAvailability(race, source);
+    const gender = allowGender ? document.querySelector('input[name="gender"]:checked')?.value || "men" : null;
+
+    if (pushHistory) {
+      writeCanonicalQuery(race, source, gender);
+    }
+
+    showLoading();
+    updateRolldownInfo(source, race);
+    refreshSlotSummary(race, gender);
+
+    if (source === "official_ag" && race.results_urls && race.results_urls.official_ag) {
+      const url = race.results_urls.official_ag;
+      if (race.distance === "70.3" && typeof url === "object") {
+        if (url[gender] && url[gender] !== "") {
+          attachIframeLoadHandler();
+          iframe.src = url[gender];
+          iframe.style.display = "block";
+          messageArea.style.display = "none";
+        } else {
+          iframe.style.display = "none";
+          messageArea.style.display = "block";
+          messageArea.innerText = "Coming Soon!";
+          hideLoading();
+        }
+      } else if (race.distance === "140.6") {
+        if (typeof url === "object" && url !== null) {
+          if (gender && url[gender] && url[gender] !== "") {
+            attachIframeLoadHandler();
+            iframe.src = url[gender];
+            iframe.style.display = "block";
+            messageArea.style.display = "none";
+          } else {
+            iframe.style.display = "none";
+            messageArea.style.display = "block";
+            messageArea.innerText = "Coming Soon!";
+            hideLoading();
+          }
+        } else if (typeof url === "string") {
+          attachIframeLoadHandler();
+          iframe.src = url;
+          iframe.style.display = "block";
+          messageArea.style.display = "none";
+        }
+      }
+    } else {
+      const slotPolicy = race.slot_policy || "";
+      const isSplit = slotPolicy.startsWith("split");
+      const baseLivePath = isSplit ? `/live_results/${slugifyRace(selectedRaceName)}/${gender}` : `/live_results/${slugifyRace(selectedRaceName)}`;
+      const liveUrlObj = new URL(baseLivePath, window.location.origin);
+      const currentTheme = getCurrentTheme();
+      if (currentTheme === "dark" || currentTheme === "light") {
+        liveUrlObj.searchParams.set("theme", currentTheme);
+      }
+      attachIframeLoadHandler();
+      iframe.src = liveUrlObj.pathname + liveUrlObj.search;
+      iframe.style.display = "block";
+      messageArea.style.display = "none";
+    }
+  }
+
+  raceSelect.addEventListener("change", () => {
+    hasUserInteracted = true;
+    if (isCurrentRace(raceSelect.value)) {
+      raceSearch.value = "";
+      setCurrentRacesCollapsed(false);
+    } else {
+      setRaceSearchToSelected();
+      setCurrentRacesCollapsed(true);
+    }
+    updateCurrentRaceSelectionUI(raceSelect.value);
+    updateAll(true);
+  });
+  sourceRadios.forEach((radio) => {
+    radio.addEventListener("change", () => {
+      hasUserInteracted = true;
+      updateAll(true);
+    });
+  });
+  genderRadios.forEach((radio) => {
+    radio.addEventListener("change", () => {
+      hasUserInteracted = true;
+      updateAll(true);
+    });
+  });
+
+  if (raceSearch) {
+    raceSearch.addEventListener("focus", () => {
+      renderRaceOptions(raceSearch.value);
+      openRaceOptions();
+    });
+    raceSearch.addEventListener("input", () => {
+      renderRaceOptions(raceSearch.value);
+      openRaceOptions();
+    });
+    raceSearch.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        const firstOption = raceOptions ? raceOptions.querySelector(".race-option-item") : null;
+        if (firstOption) {
+          firstOption.click();
+        } else {
+          closeRaceOptions();
+        }
+      } else if (event.key === "Escape") {
+        closeRaceOptions();
+      }
+    });
+  }
+
+  if (raceDropdownToggle) {
+    raceDropdownToggle.addEventListener("click", () => {
+      const isOpen = raceOptions && !raceOptions.classList.contains("hidden");
+      if (isOpen) {
+        closeRaceOptions();
+      } else {
+        renderRaceOptions(raceSearch ? raceSearch.value : "");
+        openRaceOptions();
+      }
+    });
+  }
+
+  if (currentRaceButtons) {
+    currentRaceButtons.querySelectorAll(".current-race-btn").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        selectRaceValue(btn.getAttribute("data-race-name"), true);
+      });
+    });
+  }
+
+  if (currentRacesHeader) {
+    currentRacesHeader.addEventListener("click", () => {
+      const isCollapsed = currentRacesPanel ? currentRacesPanel.classList.contains("collapsed") : false;
+      setCurrentRacesCollapsed(!isCollapsed);
+    });
+    currentRacesHeader.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        const isCollapsed = currentRacesPanel ? currentRacesPanel.classList.contains("collapsed") : false;
+        setCurrentRacesCollapsed(!isCollapsed);
+      }
+    });
+  }
+
+  document.addEventListener("click", (event) => {
+    if (!event.target.closest(".race-combobox") && !event.target.closest("#race-options")) {
+      closeRaceOptions();
+    }
+  });
+
+  window.addEventListener("popstate", () => {
+    syncFromUrl(window.location.search);
+  });
+
+  window.addEventListener("canikona:theme-changed", () => {
+    applyThemeParamToLiveIframe();
+    notifyLiveIframeTheme();
+  });
+
+  window.addEventListener("message", (event) => {
+    if (event.origin !== window.location.origin) return;
+    if (!event.data || event.data.type !== "canikona:live-results-ready") return;
+    notifyLiveIframeTheme();
+  });
+
+  if (raceSearch) {
+    const selectedNow = currentRaceOption();
+    if (selectedNow && isCurrentRace(selectedNow.value)) {
+      raceSearch.value = "";
+      setCurrentRacesCollapsed(false);
+      updateCurrentRaceSelectionUI(selectedNow.value);
+    } else {
+      setRaceSearchToSelected();
+      setCurrentRacesCollapsed(true);
+      updateCurrentRaceSelectionUI(selectedNow ? selectedNow.value : "");
+    }
+  }
+  if (window.location.search.includes("race=")) {
+    syncFromUrl(window.location.search);
+  } else {
+    updateAll(false);
+  }
+});

--- a/static/js/nav.js
+++ b/static/js/nav.js
@@ -1,0 +1,57 @@
+const THEME_STORAGE_KEY = "canikona:theme";
+
+function applyTheme(theme) {
+  document.documentElement.setAttribute("data-theme", theme);
+}
+
+function loadInitialTheme() {
+  try {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    if (stored === "dark" || stored === "light") {
+      applyTheme(stored);
+      return;
+    }
+  } catch (_) {}
+
+  const prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+  applyTheme(prefersDark ? "dark" : "light");
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  loadInitialTheme();
+
+  const navToggle = document.querySelector(".nav-toggle");
+  const navMenu = document.querySelector(".nav-menu");
+  const body = document.body;
+  const themeToggle = document.getElementById("theme-toggle");
+
+  if (navToggle && navMenu) {
+    navToggle.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      navMenu.classList.toggle("active");
+      body.classList.toggle("menu-open");
+      navToggle.classList.toggle("active");
+    });
+
+    document.addEventListener("click", (event) => {
+      if (!event.target.closest(".nav-menu") && !event.target.closest(".nav-toggle") && navMenu.classList.contains("active")) {
+        navMenu.classList.remove("active");
+        body.classList.remove("menu-open");
+        navToggle.classList.remove("active");
+      }
+    });
+  }
+
+  if (themeToggle) {
+    themeToggle.addEventListener("click", () => {
+      const current = document.documentElement.getAttribute("data-theme") || "light";
+      const next = current === "dark" ? "light" : "dark";
+      applyTheme(next);
+      try {
+        localStorage.setItem(THEME_STORAGE_KEY, next);
+      } catch (_) {}
+      window.dispatchEvent(new CustomEvent("canikona:theme-changed", { detail: { theme: next } }));
+    });
+  }
+});

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,454 +6,94 @@
 {% endblock %}
 
 {% block content %}
-<h1>{{ page_title }}</h1>
+<header class="page-header">
+    <h1>{{ page_title }}</h1>
+    <p class="page-subtitle">Track live standings or official rolldown lists, then share a direct link to your selected view.</p>
+</header>
 
-        <div class="controls-container">
-            <form id="selection-form">
-                <div class="selection-group">
-                    <label for="race-select">Race:</label>
-                    <select name="race_name" id="race-select">
-                        {% for race in races %}
-                            <option value="{{ race.name }}"
-                                    data-distance="{{ race.distance }}"
-                                    data-slots="{{ race.slots if race.distance == '140.6' else '' }}"
-                                    data-slots-men="{{ race.slots.men if race.distance == '70.3' else '' }}"
-                                    data-slots-women="{{ race.slots.women if race.distance == '70.3' else '' }}"
-                                    data-slot-policy="{{ race.slot_policy if race.slot_policy else '' }}"
-                                    {% if race.name == selected_race %}selected{% endif %}>
-                                {{ race.date }} - {{ race.name }}
-                            </option>
-                        {% endfor %}
-                    </select>
-                    <div id="slots-display" class="slots-info"></div>
+<section class="controls-container" aria-label="Results controls">
+    <form id="selection-form">
+        <div class="selection-group control-card race-card">
+            <h2 class="control-title">Search race</h2>
+            <div id="current-races-panel" class="current-races-panel">
+                <div class="current-races-header" id="current-races-header" role="button" tabindex="0" aria-expanded="true">
+                    <span>Current Races</span>
+                    <span id="current-races-count">{{ current_races | length }}</span>
                 </div>
-
-                <div class="selection-group">
-                    <p>Data Source:</p>
-                    <label><input type="radio" name="data_source" value="live" {% if selected_source == 'live' %}checked{% endif %}> Live</label>
-                    <label><input type="radio" name="data_source" value="official_ag" {% if selected_source == 'official_ag' %}checked{% endif %}> Official Rolldown List</label>
+                <div id="current-race-buttons" class="current-race-buttons">
+                    {% for race in current_races %}
+                    <button type="button"
+                            class="current-race-btn"
+                            data-race-name="{{ race.name }}">
+                        {{ race.control_label }}
+                    </button>
+                    {% endfor %}
                 </div>
-
-                <div id="gender-selection" class="selection-group">
-                    <p>Gender:</p>
-                    <label><input type="radio" name="gender" value="men" {% if selected_gender == 'men' %}checked{% endif %}> Men</label>
-                    <label><input type="radio" name="gender" value="women" {% if selected_gender == 'women' %}checked{% endif %}> Women</label>
+            </div>
+            <div class="archive-header">Race Archives</div>
+            <div class="archive-dropdown">
+                <div class="race-combobox">
+                    <input id="race-search" placeholder="Search archives" autocomplete="off">
+                    <button type="button" id="race-dropdown-toggle" aria-label="Browse races" aria-expanded="false">▼</button>
                 </div>
-            </form>
+                <div id="race-options" class="race-options hidden" role="listbox" aria-label="Race options"></div>
+            </div>
+            <label for="race-select" class="hidden-label">Race selector</label>
+            <select name="race_name" id="race-select">
+                {% for race in races %}
+                <option value="{{ race.name }}"
+                        data-race-label="{{ race.date }} - {{ race.name }}"
+                        data-distance="{{ race.distance }}"
+                        data-slots="{{ race.slots if race.distance == '140.6' else '' }}"
+                        data-slots-men="{{ race.slots.men if race.distance == '70.3' else '' }}"
+                        data-slots-women="{{ race.slots.women if race.distance == '70.3' else '' }}"
+                        data-slot-policy="{{ race.slot_policy if race.slot_policy else '' }}"
+                        {% if race.name == selected_race %}selected{% endif %}>
+                    {{ race.date }} - {{ race.name }}
+                </option>
+                {% endfor %}
+            </select>
         </div>
 
-    <div id="slot-summary-container">
-        {% include 'partials/slot_summary.html' %}
-    </div>
-
-        <div id="results-display">
-            <!-- Loading overlay with spinner -->
-            <div id="loading-overlay">
-                <div class="spinner"></div>
-            </div>
-
-            <!-- Rolldown information for official results -->
-            <div id="rolldown-info" class="rolldown-message">
-                <div id="rolldown-content"></div>
-            </div>
-
-            <!-- Results containers -->
-            <div id="message-area"></div>
-            <iframe id="results-iframe" frameborder="0"></iframe>
+        <div class="selection-group control-card">
+            <h2 class="control-title">Data Source</h2>
+            <label class="choice-option"><input type="radio" name="data_source" value="live" {% if selected_source == 'live' %}checked{% endif %}> Live</label>
+            <label class="choice-option"><input type="radio" name="data_source" value="official_ag" {% if selected_source == 'official_ag' %}checked{% endif %}> Official Rolldown List</label>
         </div>
+
+        <div id="gender-selection" class="selection-group control-card">
+            <h2 class="control-title">Gender</h2>
+            <label class="choice-option"><input type="radio" name="gender" value="men" {% if selected_gender == 'men' %}checked{% endif %}> Men</label>
+            <label class="choice-option"><input type="radio" name="gender" value="women" {% if selected_gender == 'women' %}checked{% endif %}> Women</label>
+        </div>
+    </form>
+</section>
+
+<div id="slot-summary-container">
+    {% include 'partials/slot_summary.html' %}
+</div>
+
+<section id="results-display" aria-live="polite">
+    <div id="loading-overlay">
+        <div class="spinner"></div>
     </div>
 
-    <script>
-    const racesData = {{ races | tojson }};
+    <div id="rolldown-info" class="rolldown-message">
+        <div id="rolldown-content"></div>
+    </div>
 
-        function setupTooltip(tooltipContainer) {
-            const icon = tooltipContainer.querySelector('.tooltip-icon');
-            icon.addEventListener('click', (e) => {
-                e.stopPropagation();  // Prevent document click from immediately closing
-                // Close any other open tooltips
-                document.querySelectorAll('.tooltip.active').forEach(t => {
-                    if (t !== tooltipContainer) t.classList.remove('active');
-                });
-                tooltipContainer.classList.toggle('active');
-            });
-        }
+    <div id="message-area"></div>
+    <iframe id="results-iframe" frameborder="0"></iframe>
+</section>
 
-        // Close tooltips when clicking outside
-        document.addEventListener('click', (e) => {
-            if (!e.target.closest('.tooltip')) {
-                document.querySelectorAll('.tooltip.active').forEach(tooltip => {
-                    tooltip.classList.remove('active');
-                });
-            }
-        });
-
-    function updateRolldownInfo(source, race) {
-            const rolldownDiv = document.getElementById('rolldown-info');
-            const rolldownContent = document.getElementById('rolldown-content');
-
-            // Hide rolldown info if not official_ag source
-            if (source !== 'official_ag') {
-                rolldownDiv.style.display = 'none';
-                return;
-            }
-
-            // Hide if no race found or no known_rolldown available for this race
-            if (!race) {
-                rolldownDiv.style.display = 'none';
-                return;
-            }
-
-            // For 70.3 races, check gender-specific rolldown; for 140.6, use the number directly
-            let rolldownPosition = null;
-            if (race.known_rolldown) {
-                if (race.distance === '70.3') {
-                    const selectedGender = document.querySelector('input[name="gender"]:checked')?.value;
-                    if (selectedGender && race.known_rolldown[selectedGender]) {
-                        rolldownPosition = race.known_rolldown[selectedGender];
-                    }
-                } else if (race.distance === '140.6') {
-                    if (typeof race.known_rolldown === 'number') {
-                        rolldownPosition = race.known_rolldown;
-                    }
-                }
-            }
-
-            let content = '';
-            if (rolldownPosition) {
-                // Display message with known rolldown data
-                content = `<span class="rolldown-content-text">
-                        <strong>Performance Pool Info</strong>:
-                        The performance pool rolled down to at least position <strong>${rolldownPosition}</strong> for this race.
-                    </span>
-                    <span class="tooltip">
-                        <span class="tooltip-icon">ⓘ</span>
-                        <span class="tooltip-text">Are you aware of a performance pool spot at a later number? <a href="/about">Contact the site admin</a> and we'll update this info.</span>
-                    </span>`;
-            } else {
-                // Display message asking for rolldown data
-                content = `<p class="rolldown-content-text">
-                    <strong>Performance Pool Info</strong>:
-                    Did you get a performance pool slot? Do you know how far the performance pool rolled down for this race? <a href="/about">Contact the site admin</a> and we'll display that info here.
-                </p>`;
-            }
-
-            rolldownContent.innerHTML = content;
-            rolldownDiv.style.display = 'block';
-
-            // Setup tooltip if present
-            const tooltip = rolldownContent.querySelector('.tooltip');
-            if (tooltip) {
-                setupTooltip(tooltip);
-            }
-        }
-
-    function updateSlotsDisplay() {
-            const raceSelect = document.getElementById('race-select');
-            const selectedOption = raceSelect.options[raceSelect.selectedIndex];
-            const slotsDisplay = document.getElementById('slots-display');
-            const distance = selectedOption.getAttribute('data-distance');
-            const genderInputs = document.getElementsByName('gender');
-
-            const slotPolicy = selectedOption.getAttribute('data-slot-policy') || '';
-            const isSplit = slotPolicy.startsWith('split');
-
-            // Ensure there's always a selected gender for split policies
-            if (isSplit && ![...genderInputs].some(input => input.checked)) {
-                genderInputs[0].checked = true;
-            }
-
-            const selectedGender = [...genderInputs].find(input => input.checked)?.value;
-
-            // Common tooltip markup
-            const tooltipHtml = `<span class="tooltip">
-                <span class="tooltip-icon">ⓘ</span>
-                <span class="tooltip-text">
-                    Total number of slots allocated to the race; see the
-                    <a href="https://www.ironman.com/about/age-group-qualification" target="_blank">Age
-                    Group Qualification System</a> page for details on how slots will be assigned.
-                </span>
-            </span>`;
-
-            if (distance === '140.6') {
-                const totalSlots = selectedOption.getAttribute('data-slots');
-                slotsDisplay.innerHTML = `Available Slots: <strong>${totalSlots}</strong>${tooltipHtml}`;
-                slotsDisplay.style.display = 'block';
-                setupTooltip(slotsDisplay.querySelector('.tooltip'));
-            } else if (distance === '70.3' && selectedGender) {
-                const slots = selectedGender === 'men'
-                    ? selectedOption.getAttribute('data-slots-men')
-                    : selectedOption.getAttribute('data-slots-women');
-                const genderDisplay = selectedGender === 'men' ? 'Men' : 'Women';
-                slotsDisplay.innerHTML = `Available Slots For ${genderDisplay}: <strong>${slots}</strong>${tooltipHtml}`;
-                slotsDisplay.style.display = 'block';
-                setupTooltip(slotsDisplay.querySelector('.tooltip'));
-            } else {
-                slotsDisplay.style.display = 'none';
-            }
-        }
-
-        function findRaceData(raceName) {
-            return racesData.find(race => race.name === raceName);
-        }
-
-        async function refreshSlotSummary(race, gender) {
-            try {
-                const name = (race?.name || '').replace(/ /g, '_');
-                if (!name) return;
-                const params = new URLSearchParams();
-                if (gender) params.set('gender', gender);
-                const res = await fetch(`/fragment/slot_summary/${name}?${params.toString()}`);
-                if (!res.ok) return;
-                const html = await res.text();
-                const container = document.getElementById('slot-summary-container');
-                if (!container) return;
-                container.innerHTML = html;
-
-                // Execute any inline scripts inside the injected HTML
-                const scripts = Array.from(container.querySelectorAll('script'));
-                scripts.forEach((oldScript) => {
-                    const s = document.createElement('script');
-                    // Copy attributes
-                    for (const attr of oldScript.attributes) {
-                        s.setAttribute(attr.name, attr.value);
-                    }
-                    s.text = oldScript.textContent || '';
-                    // Use body append to ensure execution context
-                    document.body.appendChild(s);
-                    // Remove the original to avoid duplicates
-                    oldScript.remove();
-                });
-            } catch (e) {
-                // Silent failure; panel just won't update
-            }
-        }
-
-        document.addEventListener('DOMContentLoaded', function() {
-            const raceSelect = document.getElementById('race-select');
-            const sourceRadios = document.querySelectorAll('input[name="data_source"]');
-            const genderRadios = document.querySelectorAll('input[name="gender"]');
-            const genderDiv = document.getElementById('gender-selection');
-            const iframe = document.getElementById('results-iframe');
-            const messageArea = document.getElementById('message-area');
-            const loadingOverlay = document.getElementById('loading-overlay');
-
-            // Initialize slots display
-            updateSlotsDisplay();
-
-            // Handle race selection changes
-            raceSelect.addEventListener('change', function() {
-                const distance = this.options[this.selectedIndex].getAttribute('data-distance');
-                // When switching to 70.3, ensure first gender option is selected
-                if (distance === '70.3') {
-                    const menRadio = document.querySelector('input[name="gender"][value="men"]');
-                    menRadio.checked = true;
-                }
-                updateSlotsDisplay();
-            });
-
-            // Handle gender selection changes
-            genderRadios.forEach(radio => {
-                radio.addEventListener('change', updateSlotsDisplay);
-            });
-
-            function showLoading() {
-                loadingOverlay.style.display = 'block';
-                iframe.style.display = 'none';
-                messageArea.style.display = 'none';
-            }
-
-            function hideLoading() {
-                loadingOverlay.style.display = 'none';
-            }
-
-            async function updateAll() {
-                const selectedRaceName = raceSelect.value;
-                const race = findRaceData(selectedRaceName);
-                const source = document.querySelector('input[name="data_source"]:checked').value;
-                const slotPolicy = race.slot_policy || '';
-                const isSplit = slotPolicy.startsWith('split');
-                const is703 = race.distance === '70.3';
-
-                // Determine if gender selection should be enabled
-                const officialAg = race.results_urls?.official_ag;
-                const officialGendered = (
-                    source === 'official_ag' && race.distance === '140.6' &&
-                    typeof officialAg === 'object' && officialAg !== null && (
-                        (officialAg.men && officialAg.men.trim()) || (officialAg.women && officialAg.women.trim())
-                    )
-                );
-                const allowGender = isSplit || officialGendered;
-
-                if (allowGender) {
-                    genderDiv.classList.remove('disabled-controls');
-                    genderRadios.forEach(radio => radio.disabled = false);
-                    // Ensure some gender is selected
-                    const checked = document.querySelector('input[name="gender"]:checked');
-                    if (!checked) {
-                        const menRadio = document.querySelector('input[name="gender"][value="men"]');
-                        if (menRadio) menRadio.checked = true;
-                    }
-                } else {
-                    genderDiv.classList.add('disabled-controls');
-                    genderRadios.forEach(radio => radio.disabled = true);
-                }
-
-                const gender = allowGender ? (document.querySelector('input[name="gender"]:checked')?.value || 'men') : null;
-
-                const urlFriendlyName = selectedRaceName.replace(/ /g, '_');
-                let urlPath = `/results/${urlFriendlyName}/${source}`;
-                if (isSplit || officialGendered) {
-                    urlPath += `/${gender}`;
-                }
-                window.history.pushState({}, '', urlPath);
-
-                // Scroll to top of page smoothly and show loading
-                window.scrollTo({
-                    top: 0,
-                    behavior: 'smooth'
-                });
-                showLoading();
-
-                // Refresh the slot summary fragment to reflect the newly selected race/gender
-                refreshSlotSummary(race, allowGender ? gender : null);
-
-                updateRolldownInfo(source, race);
-
-                if (source === 'official_ag' && race.results_urls && race.results_urls.official_ag) {
-                    let url = race.results_urls.official_ag;
-                    if (is703) {
-                        // Handle 70.3 race with gender-specific URLs
-                        if (url[gender] && url[gender] !== "") {
-                            iframe.onload = hideLoading;
-                            iframe.src = url[gender];
-                            iframe.style.display = 'block';
-                            messageArea.style.display = 'none';
-                        } else {
-                            iframe.style.display = 'none';
-                            messageArea.style.display = 'block';
-                            messageArea.innerText = 'Coming Soon!';
-                        }
-                    } else if (race.distance === '140.6') {
-                        // 140.6: can be single URL or gendered dict
-                        if (typeof url === 'object' && url !== null) {
-                            if (gender && url[gender] && url[gender] !== '') {
-                                iframe.onload = hideLoading;
-                                iframe.src = url[gender];
-                                iframe.style.display = 'block';
-                                messageArea.style.display = 'none';
-                            } else {
-                                iframe.style.display = 'none';
-                                messageArea.style.display = 'block';
-                                messageArea.innerText = 'Coming Soon!';
-                            }
-                        } else if (typeof url === 'string') {
-                            iframe.onload = hideLoading;
-                            iframe.src = url;
-                            iframe.style.display = 'block';
-                            messageArea.style.display = 'none';
-                        } else {
-                            iframe.style.display = 'none';
-                            messageArea.style.display = 'block';
-                            messageArea.innerText = 'Coming Soon!';
-                        }
-                    } else {
-                        iframe.style.display = 'none';
-                        messageArea.style.display = 'block';
-                        messageArea.innerText = 'Coming Soon!';
-                    }
-                } else if (source === 'live') {
-                    let liveUrl = isSplit
-                        ? `/live_results/${urlFriendlyName}/${gender}`
-                        : `/live_results/${urlFriendlyName}`;
-                    iframe.onload = hideLoading;
-                    iframe.src = liveUrl;
-                    iframe.style.display = 'block';
-                    messageArea.style.display = 'none';
-
-                } else {
-                    iframe.style.display = 'none';
-                    messageArea.style.display = 'block';
-                    messageArea.innerText = 'Coming Soon!';
-                    hideLoading();
-                }
-            }
-
-            let isInitialLoad = true;
-
-            function onRaceChange() {
-                // Determine current race
-                const selectedRaceName = isInitialLoad ? ('{{ selected_race }}' || raceSelect.value) : raceSelect.value;
-                const race = findRaceData(selectedRaceName);
-
-                // Helpers to query radios and availability
-                const officialAgRadio = document.querySelector('input[name="data_source"][value="official_ag"]');
-                const liveRadio = document.querySelector('input[name="data_source"][value="live"]');
-
-                function officialAvailable(r) {
-                    if (!r || !r.results_urls || !('official_ag' in r.results_urls)) return false;
-                    if (r.distance === '70.3') {
-                        const men = r.results_urls.official_ag?.men ?? '';
-                        const women = r.results_urls.official_ag?.women ?? '';
-                        return Boolean((men && men.trim()) || (women && women.trim()));
-                    }
-                    const url = r.results_urls.official_ag;
-                    if (typeof url === 'string') return Boolean(url.trim());
-                    if (typeof url === 'object' && url !== null) {
-                        const men = url.men ?? '';
-                        const women = url.women ?? '';
-                        return Boolean((men && men.trim()) || (women && women.trim()));
-                    }
-                    return false;
-                }
-
-                const hasOfficialAg = officialAvailable(race);
-
-                // Enable/disable only the Official radio based on availability
-                officialAgRadio.disabled = !hasOfficialAg;
-                officialAgRadio.parentElement.classList.toggle('disabled-controls', !hasOfficialAg);
-
-                // Live should always be available
-                liveRadio.disabled = false;
-                liveRadio.parentElement.classList.remove('disabled-controls');
-
-                // Selection policy
-                // 1) On initial load: honor server-provided selected_source if available; else fall back smartly
-                // 2) On subsequent race changes: preserve user's current selection if it's still valid; otherwise fall back
-                const serverSelected = '{{ selected_source }}';
-                const currentChecked = document.querySelector('input[name="data_source"]:checked')?.value;
-
-                let nextSource = currentChecked || 'live';
-                if (isInitialLoad && serverSelected) {
-                    // Use server value only if it's valid for this race
-                    if (serverSelected === 'official_ag' && hasOfficialAg) {
-                        nextSource = 'official_ag';
-                    } else {
-                        nextSource = 'live';
-                    }
-                } else {
-                    // If current selection is official but it's not available for this race, fall back to live
-                    if (currentChecked === 'official_ag' && !hasOfficialAg) {
-                        nextSource = 'live';
-                    }
-                }
-
-                // Apply selection
-                document.querySelector(`input[name="data_source"][value="${nextSource}"]`).checked = true;
-                isInitialLoad = false;
-
-                // For 70.3 ensure a gender is picked (default to men)
-                if (race.distance === '70.3') {
-                    document.querySelector('input[name="gender"][value="men"]').checked = true;
-                }
-
-                updateAll();
-            }
-
-            raceSelect.addEventListener('change', onRaceChange);
-            sourceRadios.forEach(radio => radio.addEventListener('change', updateAll));
-            genderRadios.forEach(radio => radio.addEventListener('change', updateAll));
-
-            onRaceChange();
-        });
-    </script>
+<script id="page-config" type="application/json">
+    {{ {
+        "races": races,
+        "currentRaceNames": current_races | map(attribute='name') | list,
+        "selectedRace": selected_race,
+        "selectedSource": selected_source,
+        "selectedGender": selected_gender
+    } | tojson }}
+</script>
+<script src="{{ url_for('static', filename='js/home.js') }}" defer></script>
 {% endblock %}

--- a/templates/live_results.html
+++ b/templates/live_results.html
@@ -1,10 +1,42 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" {% if selected_theme %}data-theme="{{ selected_theme }}"{% endif %}>
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Live Results</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+    <script id="live-results-theme-sync">
+        (function () {
+            function applyTheme(theme) {
+                if (theme === 'dark' || theme === 'light') {
+                    document.documentElement.setAttribute('data-theme', theme);
+                }
+            }
+
+            try {
+                const parentTheme = window.parent && window.parent.document
+                    ? window.parent.document.documentElement.getAttribute('data-theme')
+                    : null;
+                applyTheme(parentTheme);
+            } catch (_) {
+                // Ignore cross-window access errors.
+            }
+
+            window.addEventListener('message', function (event) {
+                if (event.origin !== window.location.origin) return;
+                if (!event.data || event.data.type !== 'canikona:set-theme') return;
+                applyTheme(event.data.theme);
+            });
+
+            try {
+                if (window.parent && window.parent !== window) {
+                    window.parent.postMessage({ type: 'canikona:live-results-ready' }, window.location.origin);
+                }
+            } catch (_) {
+                // Ignore cross-window access errors.
+            }
+        })();
+    </script>
 </head>
 <body>
     <div id="live-results-container">

--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -1,3 +1,7 @@
+<button class="theme-toggle" id="theme-toggle" type="button" aria-label="Toggle dark mode">
+    <span class="theme-toggle-text">Dark mode</span>
+</button>
+
 <button class="nav-toggle" aria-label="Toggle navigation">
     <span class="hamburger"></span>
 </button>
@@ -10,32 +14,4 @@
     </ul>
 </nav>
 
-<script>
-    document.addEventListener('DOMContentLoaded', function() {
-        // Mobile menu functionality
-        const navToggle = document.querySelector('.nav-toggle');
-        const navMenu = document.querySelector('.nav-menu');
-        const body = document.body;
-
-        navToggle.addEventListener('click', function(e) {
-            e.preventDefault();
-            e.stopPropagation();
-            navMenu.classList.toggle('active');
-            body.classList.toggle('menu-open');
-
-            // Toggle hamburger animation
-            this.classList.toggle('active');
-        });
-
-        // Close menu when clicking outside
-        document.addEventListener('click', function(event) {
-            if (!event.target.closest('.nav-menu') &&
-                !event.target.closest('.nav-toggle') &&
-                navMenu.classList.contains('active')) {
-                navMenu.classList.remove('active');
-                body.classList.remove('menu-open');
-                navToggle.classList.remove('active');
-            }
-        });
-    });
-</script>
+<script src="{{ url_for('static', filename='js/nav.js') }}" defer></script>

--- a/tests/test_home_js_contracts.py
+++ b/tests/test_home_js_contracts.py
@@ -1,0 +1,57 @@
+import pathlib
+
+
+def _home_js():
+    path = pathlib.Path(__file__).resolve().parents[1] / "static" / "js" / "home.js"
+    return path.read_text(encoding="utf-8")
+
+
+def test_home_js_handles_popstate_for_browser_navigation():
+    content = _home_js()
+    assert "window.addEventListener(\"popstate\"" in content
+    assert "syncFromUrl(window.location.search)" in content
+
+
+def test_home_js_writes_canonical_query_urls():
+    content = _home_js()
+    assert "new URLSearchParams()" in content
+    assert "params.set(\"race\"" in content
+    assert "window.history.pushState" in content
+    assert "`/?${params.toString()}`" in content
+
+
+def test_home_js_supports_searchable_race_picker():
+    content = _home_js()
+    assert "selectRaceValue" in content
+    assert "raceSearch.addEventListener(\"input\"" in content
+    assert "renderRaceOptions(" in content
+    assert "raceDropdownToggle" in content
+    assert "setCurrentRacesCollapsed(" in content
+    assert "window.location.search.includes(\"race=\")" in content
+    assert "updateAll(false)" in content
+    assert "updateCurrentRaceSelectionUI(" in content
+    assert "currentRacesHeader.addEventListener(\"click\"" in content
+
+
+def test_home_js_propagates_theme_to_live_results_iframe():
+    content = _home_js()
+    assert "document.documentElement.getAttribute(\"data-theme\")" in content
+    assert "liveUrlObj.searchParams.set(\"theme\", currentTheme)" in content
+
+
+def test_home_js_reloads_live_iframe_on_theme_change_event():
+    content = _home_js()
+    assert "window.addEventListener(\"canikona:theme-changed\"" in content
+    assert "iframe.src.includes(\"/live_results/\")" in content
+
+
+def test_home_js_posts_theme_message_to_live_iframe():
+    content = _home_js()
+    assert "iframe.contentWindow.postMessage" in content
+    assert "canikona:set-theme" in content
+
+
+def test_home_js_handles_live_iframe_ready_handshake():
+    content = _home_js()
+    assert "window.addEventListener(\"message\"" in content
+    assert "canikona:live-results-ready" in content

--- a/tests/test_home_routing.py
+++ b/tests/test_home_routing.py
@@ -1,0 +1,149 @@
+import pathlib
+import sys
+from datetime import date
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import app as app_module
+
+
+def _race(name: str, distance: str, slot_policy: str, official_url):
+    return {
+        "name": name,
+        "date": "2026-10-01",
+        "distance": distance,
+        "earliestStartTime": 0,
+        "slots": {"men": 30, "women": 20} if distance == "70.3" else 55,
+        "slot_policy": slot_policy,
+        "known_rolldown": {"men": 8, "women": 6} if distance == "70.3" else 10,
+        "age_group_categories": {"men": [], "women": []},
+        "results_urls": {
+            "live": {"men": "https://live-men", "women": "https://live-women"},
+            "official_ag": official_url,
+        },
+    }
+
+
+def _set_test_races(monkeypatch):
+    races = [
+        _race("Alpha 70.3", "70.3", "split-fixed", {"men": "https://official-men", "women": "https://official-women"}),
+        _race("Beta 140.6", "140.6", "combined-fixed", "https://official-combined"),
+    ]
+    monkeypatch.setattr(app_module, "get_races", lambda: races)
+    monkeypatch.setattr(app_module, "get_race_by_name", lambda race_name: next((r for r in races if r["name"] == app_module.from_url_friendly_name(race_name)), None))
+
+
+def test_home_does_not_redirect_and_renders_default_race(monkeypatch):
+    _set_test_races(monkeypatch)
+    client = app_module.app.test_client()
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert b'id="selection-form"' in response.data
+    assert b"Alpha 70.3" in response.data
+
+
+def test_home_respects_canonical_query_state(monkeypatch):
+    _set_test_races(monkeypatch)
+    client = app_module.app.test_client()
+
+    response = client.get("/?race=Beta_140.6&source=official_ag")
+
+    assert response.status_code == 200
+    assert b'value="official_ag" checked' in response.data
+    assert b"Beta 140.6" in response.data
+
+
+def test_legacy_results_path_redirects_to_canonical_query(monkeypatch):
+    _set_test_races(monkeypatch)
+    client = app_module.app.test_client()
+
+    response = client.get("/results/Alpha_70.3/live/men")
+
+    assert response.status_code in (301, 302, 308)
+    assert response.headers["Location"].endswith("/?race=Alpha_70.3&source=live&gender=men")
+
+
+def test_legacy_base_results_path_redirects_with_normalized_defaults(monkeypatch):
+    _set_test_races(monkeypatch)
+    client = app_module.app.test_client()
+
+    response = client.get("/results/Beta_140.6")
+
+    assert response.status_code in (301, 302, 308)
+    assert response.headers["Location"].endswith("/?race=Beta_140.6&source=official_ag")
+
+
+def test_home_includes_theme_toggle_control(monkeypatch):
+    _set_test_races(monkeypatch)
+    client = app_module.app.test_client()
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert b'id="theme-toggle"' in response.data
+
+
+def test_controls_panel_uses_unified_section_titles_and_no_slots_duplication(monkeypatch):
+    _set_test_races(monkeypatch)
+    client = app_module.app.test_client()
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert b'class="control-title">Search race<' in response.data
+    assert b'class="control-title">Data Source<' in response.data
+    assert b'class="control-title">Gender<' in response.data
+    assert b"Current Races" in response.data
+    assert b'id="slots-display"' not in response.data
+
+
+def test_controls_panel_exposes_explicit_race_dropdown_browse_ui(monkeypatch):
+    _set_test_races(monkeypatch)
+    client = app_module.app.test_client()
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert b'id="race-dropdown-toggle"' in response.data
+    assert b'id="race-options"' in response.data
+
+
+def test_live_results_route_preserves_theme_query(monkeypatch):
+    _set_test_races(monkeypatch)
+    client = app_module.app.test_client()
+
+    response = client.get("/live_results/Alpha_70.3/men?theme=dark")
+
+    assert response.status_code == 200
+    assert b'data-theme="dark"' in response.data
+    assert b"id=\"live-results-theme-sync\"" in response.data
+    assert b"canikona:set-theme" in response.data
+    assert b"canikona:live-results-ready" in response.data
+
+
+def test_partition_races_groups_nearest_weekend_as_current():
+    races = [
+        {"name": "Sat Race", "date": "2026-05-09"},
+        {"name": "Sun Race", "date": "2026-05-10"},
+        {"name": "Older Race", "date": "2026-04-26"},
+    ]
+    current, archive = app_module.partition_races_for_controls(races, today=date(2026, 5, 7))
+    assert [r["name"] for r in current] == ["Sat Race", "Sun Race"]
+    assert [r["name"] for r in archive] == ["Older Race"]
+
+
+def test_default_race_prefers_closest_by_date():
+    races = [
+        {"name": "Older Race", "date": "2026-04-20"},
+        {"name": "Closest Race", "date": "2026-05-09"},
+        {"name": "Farther Race", "date": "2026-06-20"},
+    ]
+    picked = app_module.pick_default_race(races, today=date(2026, 5, 8))
+    assert picked["name"] == "Closest Race"
+
+
+def test_format_current_race_label_abbreviates_ironman_names():
+    assert app_module.format_current_race_label("Ironman 70.3 Gulf Coast") == "IM70.3 Gulf Coast"
+    assert app_module.format_current_race_label("Ironman Texas") == "IM Texas"

--- a/tests/test_state_and_theme_contracts.py
+++ b/tests/test_state_and_theme_contracts.py
@@ -1,0 +1,117 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import app as app_module
+
+
+def test_stylesheet_declares_light_and_dark_theme_tokens():
+    css = pathlib.Path(__file__).resolve().parents[1] / "static" / "css" / "styles.css"
+    content = css.read_text(encoding="utf-8")
+
+    assert ":root {" in content
+    assert "html[data-theme=\"dark\"]" in content
+    assert "--bg:" in content
+    assert "--surface:" in content
+    assert "--accent:" in content
+
+
+def test_stylesheet_hides_backing_race_select_for_searchable_picker():
+    css = pathlib.Path(__file__).resolve().parents[1] / "static" / "css" / "styles.css"
+    content = css.read_text(encoding="utf-8")
+
+    assert "#race-select" in content
+    assert "position: absolute" in content
+    assert "opacity: 0" in content
+    assert "pointer-events: none" in content
+
+
+def test_loading_overlay_uses_theme_tokens_not_hardcoded_white():
+    css = pathlib.Path(__file__).resolve().parents[1] / "static" / "css" / "styles.css"
+    content = css.read_text(encoding="utf-8")
+
+    assert "--loading-overlay:" in content
+    assert "--spinner-track:" in content
+    assert "--spinner-head:" in content
+    assert "background: var(--loading-overlay)" in content
+    assert "border: 8px solid var(--spinner-track)" in content
+    assert "border-top: 8px solid var(--spinner-head)" in content
+
+
+def test_slot_summary_panel_uses_theme_tokens():
+    css = pathlib.Path(__file__).resolve().parents[1] / "static" / "css" / "styles.css"
+    content = css.read_text(encoding="utf-8")
+
+    assert ".slot-summary {" in content
+    assert "background-color: var(--surface)" in content
+    assert "border: 1px solid var(--border)" in content
+
+
+def test_row_highlights_target_cells_not_row_background_only():
+    css = pathlib.Path(__file__).resolve().parents[1] / "static" / "css" / "styles.css"
+    content = css.read_text(encoding="utf-8")
+
+    assert ".row-ag-winner td {" in content
+    assert ".row-pool-qualifier td {" in content
+    assert "html[data-theme=\"dark\"] .row-ag-winner td {" in content
+    assert "html[data-theme=\"dark\"] .row-pool-qualifier td {" in content
+
+
+def test_toggle_labels_use_tokenized_high_contrast_colors():
+    css = pathlib.Path(__file__).resolve().parents[1] / "static" / "css" / "styles.css"
+    content = css.read_text(encoding="utf-8")
+
+    assert "--chip-ag-bg:" in content
+    assert "--chip-ag-text:" in content
+    assert "--chip-pool-bg:" in content
+    assert "--chip-pool-text:" in content
+    assert "background: var(--chip-ag-bg)" in content
+    assert "color: var(--chip-ag-text)" in content
+    assert "background: var(--chip-pool-bg)" in content
+    assert "color: var(--chip-pool-text)" in content
+
+
+def test_current_race_cards_have_active_and_non_overlapping_styles():
+    css = pathlib.Path(__file__).resolve().parents[1] / "static" / "css" / "styles.css"
+    content = css.read_text(encoding="utf-8")
+
+    assert ".current-race-btn.active {" in content
+    assert "grid-template-columns: repeat(3, minmax(0, 1fr));" in content
+    assert ".current-race-btn {" in content and "overflow-wrap: anywhere" in content
+    assert ".archive-dropdown {" in content
+    assert "top: calc(100% + 8px);" in content
+    assert ".selection-group:first-of-type" not in content
+    assert "width: 100%;" in content
+    assert "text-align: center;" in content
+
+
+def test_normalize_selection_falls_back_from_unavailable_official_source():
+    race = {
+        "distance": "70.3",
+        "slot_policy": "split-fixed",
+        "results_urls": {
+            "live": {"men": "https://live-men", "women": "https://live-women"},
+            "official_ag": {"men": "", "women": ""},
+        },
+        "earliestStartTime": 0,
+    }
+
+    selection = app_module.normalize_selection(race, source="official_ag", gender="women")
+
+    assert selection["source"] == "live"
+    assert selection["gender"] == "women"
+
+
+def test_normalize_selection_drops_gender_when_not_required():
+    race = {
+        "distance": "140.6",
+        "slot_policy": "combined-fixed",
+        "results_urls": {"live": {"men": "m", "women": "w"}, "official_ag": "https://official"},
+        "earliestStartTime": 0,
+    }
+
+    selection = app_module.normalize_selection(race, source="official_ag", gender="women")
+
+    assert selection["source"] == "official_ag"
+    assert selection["gender"] is None


### PR DESCRIPTION
## Summary
- redesign the home control pane with aligned cards, current-race chips, and archive search/dropdown behavior
- keep `/` canonical on initial load while preserving shareable query URLs after user interaction and legacy route normalization
- harden dark-mode behavior across the embedded live results view, restore highlight readability, and add regression tests/docs

## Test plan
- [x] `pytest -q`
- [x] Manual browser validation of current-race selection, archive dropdown overlay, and collapse/expand behavior
- [x] Manual dark/light theme toggle validation in parent page and embedded live results iframe

Made with [Cursor](https://cursor.com)